### PR TITLE
refactor: use vfs for plugin

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,8 +3,7 @@ import {
   addComponentsDir,
   addImports,
   addImportsDir,
-  addPlugin,
-  addTemplate,
+  addPluginTemplate,
   createResolver,
   defineNuxtModule,
   hasNuxtModule,
@@ -150,9 +149,8 @@ ${newScripts.map((i) => {
 
       if (config.globals?.length || Object.keys(config.registry || {}).length) {
         // create a virtual plugin
-        const template = addTemplate({
+        addPluginTemplate({
           filename: `modules/${name!.replace('/', '-')}.mjs`,
-          write: true,
           getContents() {
             const imports = ['useScript', 'defineNuxtPlugin']
             const inits = []
@@ -178,9 +176,6 @@ ${(config.globals || []).map(g => !Array.isArray(g)
   }
 })`
           },
-        })
-        addPlugin({
-          src: template.dst,
         })
       }
       const scriptMap = new Map<string, string>()


### PR DESCRIPTION
Raised an upstream PR to resolve https://github.com/nuxt/scripts/issues/31 - with that in mind I think we can revert back to using VFS instead of writing this to disk. (May have some perf benefit.) If there's another reason you wanted to write it to disk, we can just make the change to `addPluginTemplate`....