### PR TITLE
docs: fix links to Youtube Player

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -188,7 +188,7 @@ export const registry: (resolve?: (s: string) => string) => RegistryScripts = (r
       },
     },
     {
-      label: 'YouTube Iframe',
+      label: 'YouTube Player',
       category: 'content',
       logo: `<svg xmlns="http://www.w3.org/2000/svg" width="45.52" height="32" viewBox="0 0 256 180"><path fill="red" d="M250.346 28.075A32.18 32.18 0 0 0 227.69 5.418C207.824 0 127.87 0 127.87 0S47.912.164 28.046 5.582A32.18 32.18 0 0 0 5.39 28.24c-6.009 35.298-8.34 89.084.165 122.97a32.18 32.18 0 0 0 22.656 22.657c19.866 5.418 99.822 5.418 99.822 5.418s79.955 0 99.82-5.418a32.18 32.18 0 0 0 22.657-22.657c6.338-35.348 8.291-89.1-.164-123.134"/><path fill="#FFF" d="m102.421 128.06l66.328-38.418l-66.328-38.418z"/></svg>`,
       import: {


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When I accessed the Youtube Player page using the following flow line, a 404 error was returned.

- 🆖 `/` page: Click Youtube Logo
- 🆖 `/scripts` page: Click `Youtube Iframe` content
- 🆗 `scripts` page, side menu: Click `Content > Youtube Player`

When we investigated the cause, we found that it failed in the case of **Youtube Iframe**.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.