### PR TITLE
fix: don't use aliases in build-time files

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -23,7 +23,7 @@ import type {
   NuxtUseScriptInput,
   NuxtUseScriptOptions,
   RegistryScripts,
-} from '#nuxt-scripts'
+} from './runtime/types'
 
 export interface ModuleOptions {
   /**

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -5,7 +5,7 @@ import type { SegmentInput } from './runtime/registry/segment'
 import type { NpmInput } from './runtime/registry/npm'
 import type { PlausibleAnalyticsInput } from './runtime/registry/plausible-analytics'
 import type { GoogleAnalyticsInput } from './runtime/registry/google-analytics'
-import type { RegistryScripts } from '#nuxt-scripts'
+import type { RegistryScripts } from './runtime/types'
 
 // avoid nuxt/kit dependency here so we can use in docs
 


### PR DESCRIPTION
Currently using build-time types prevent having good strict types in module integrations.

This is due to @nuxt/scripts importing `#nuxt-scripts` alias in type declaration which typescript cannot be aware of, except if the module author extends its tsconfig from a playground tsconfig (but this brings other issues)