### PR TITLE
feat: expose runtime composables

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,14 @@
     "./registry": {
       "types": "./dist/registry.d.ts",
       "import": "./dist/registry.mjs"
+    },
+    "./runtime/composables/useScript": {
+      "types": "./dist/runtime/composables/useScript.d.ts",
+      "import": "./dist/runtime/composables/useScript.mjs"
+    },
+    "./runtime/composables/composables/useElementScriptTrigger": {
+      "types": "./dist/runtime/composables/useElementScriptTrigger.d.ts",
+      "import": "./dist/runtime/composables/useElementScriptTrigger.mjs"
     }
   },
   "main": "./dist/module.cjs",


### PR DESCRIPTION
following #57 . Module authors that don't extends their tsconfig from the playground canno't import things like `useScripts` from `#imports` without having type issues, we should expose core composables from the package.

Should we improve this by exposing  a single file for `./runtime/core` instead ? or directly `./runtime`