### PR TITLE
fix: fix google namespace augmentation

### DIFF
--- a/src/runtime/registry/google-maps.ts
+++ b/src/runtime/registry/google-maps.ts
@@ -8,7 +8,6 @@ import type { RegistryScriptInput } from '#nuxt-scripts'
 declare namespace google {
   // eslint-disable-next-line ts/no-namespace
   export namespace maps {
-
     /**
      * @internal
      */

--- a/src/runtime/registry/google-maps.ts
+++ b/src/runtime/registry/google-maps.ts
@@ -4,6 +4,18 @@ import { useRegistryScript } from '../utils'
 import { array, literal, object, optional, string, union } from '#nuxt-scripts-validator'
 import type { RegistryScriptInput } from '#nuxt-scripts'
 
+// eslint-disable-next-line ts/no-namespace
+declare namespace google {
+  // eslint-disable-next-line ts/no-namespace
+  export namespace maps {
+
+    /**
+     * @internal
+     */
+    export function __ib__(): void
+  }
+}
+
 export const GoogleMapsOptions = object({
   apiKey: string(),
   libraries: optional(array(string())),
@@ -12,13 +24,6 @@ export const GoogleMapsOptions = object({
 
 export type GoogleMapsInput = RegistryScriptInput<typeof GoogleMapsOptions>
 
-// eslint-disable-next-line ts/no-namespace
-declare namespace google.maps {
-  /**
-   * @internal
-   */
-  export function __ib__(): void
-}
 export interface GoogleMapsApi {
   maps: typeof google.maps
 }


### PR DESCRIPTION
Seems like rollup dts doesn't like augmenting namespaces thats are nested with a single `.` like `google.map` on my  side . When building we can get `  namespace must have a "ModuleBlock" body.   ` error


Did you manage to build locally @harlan-zw  ?