### PR TITLE
fix(vimeo): vimeo player to reference types

### DIFF
--- a/src/runtime/components/ScriptVimeoPlayer.vue
+++ b/src/runtime/components/ScriptVimeoPlayer.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
+/// <reference types="vimeo__player" />
 import { type HTMLAttributes, type ImgHTMLAttributes, computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import type Player from 'vimeo__player'
-import type { EventMap, VimeoVideoQuality } from 'vimeo__player'
 import { defu } from 'defu'
 import type { ElementScriptTrigger } from '../composables/useElementScriptTrigger'
 import { useAsyncData, useElementScriptTrigger, useHead, useScriptVimeoPlayer } from '#imports'

--- a/src/runtime/registry/vimeo-player.ts
+++ b/src/runtime/registry/vimeo-player.ts
@@ -1,4 +1,4 @@
-import type ScriptVimeoPlayer from 'vimeo__player'
+/// <reference types="vimeo__player" />
 import { watch } from 'vue'
 import { useRegistryScript } from '../utils'
 import type { RegistryScriptInput } from '#nuxt-scripts'
@@ -6,7 +6,7 @@ import { useHead } from '#imports'
 
 export interface VimeoPlayerApi {
   Vimeo: {
-    Player: ScriptVimeoPlayer
+    Player: VimeoPlayerApi
   }
 }
 


### PR DESCRIPTION
Looks like there can be some issues when importing vimeo player. This PR moves vimeo__player imports directly to `<reference>`

![image](https://github.com/nuxt/scripts/assets/63512348/2ab072bc-39a4-48b8-bd8c-e2da297e6b77)
