### PR TITLE
build: add #nuxt-scripts-validator to externals

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "externals": [
       "@unhead/vue",
       "@unhead/schema",
-      "#nuxt-scripts"
+      "#nuxt-scripts",
+      "#nuxt-scripts-validator"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds `#nuxt-scripts-validator` to `externals`
![image](https://github.com/nuxt/scripts/assets/63512348/cd521b5e-d633-4652-aa21-f4c14f599861)
