### PR TITLE
fix(gmap): fix gmap types being overriden

### DIFF
--- a/src/runtime/components/ScriptGoogleMaps.vue
+++ b/src/runtime/components/ScriptGoogleMaps.vue
@@ -144,7 +144,7 @@ onMounted(() => {
   })
   // create the map
   $script.then(async (instance) => {
-    const maps = await instance.maps as typeof google.maps
+    const maps = await instance.maps
     const _map = new maps.Map(mapEl.value!, options.value)
     const placesService = new maps.places.PlacesService(_map)
 

--- a/src/runtime/registry/google-maps.ts
+++ b/src/runtime/registry/google-maps.ts
@@ -24,7 +24,7 @@ export const GoogleMapsOptions = object({
 export type GoogleMapsInput = RegistryScriptInput<typeof GoogleMapsOptions>
 
 export interface GoogleMapsApi {
-  maps: typeof google.maps
+  maps: typeof window.google.maps
 }
 
 declare global {


### PR DESCRIPTION
seems like we need to use `typeof window['namespace']` to correctly type the api types when using namespaces