### PR TITLE
fix: force useRegistry return type

### DIFF
--- a/src/runtime/registry/vimeo-player.ts
+++ b/src/runtime/registry/vimeo-player.ts
@@ -1,6 +1,5 @@
 /// <reference types="vimeo__player" />
 import { watch } from 'vue'
-import type { VueScriptInstance } from '@unhead/vue'
 import { useRegistryScript } from '../utils'
 import type { RegistryScriptInput } from '#nuxt-scripts'
 import { useHead } from '#imports'

--- a/src/runtime/registry/vimeo-player.ts
+++ b/src/runtime/registry/vimeo-player.ts
@@ -19,9 +19,7 @@ declare global {
   interface Window extends VimeoPlayerApi {}
 }
 
-export function useScriptVimeoPlayer<T extends VimeoPlayerApi>(_options?: VimeoPlayerInput): T & {
-  $script: Promise<T> & VueScriptInstance<T>
-} {
+export function useScriptVimeoPlayer<T extends VimeoPlayerApi>(_options?: VimeoPlayerInput) {
   const instance = useRegistryScript<T>('vimeoPlayer', () => ({
     scriptInput: {
       src: 'https://player.vimeo.com/api/player.js',

--- a/src/runtime/registry/vimeo-player.ts
+++ b/src/runtime/registry/vimeo-player.ts
@@ -1,5 +1,6 @@
 /// <reference types="vimeo__player" />
 import { watch } from 'vue'
+import type { VueScriptInstance } from '@unhead/vue'
 import { useRegistryScript } from '../utils'
 import type { RegistryScriptInput } from '#nuxt-scripts'
 import { useHead } from '#imports'
@@ -18,7 +19,9 @@ declare global {
   interface Window extends VimeoPlayerApi {}
 }
 
-export function useScriptVimeoPlayer<T extends VimeoPlayerApi>(_options?: VimeoPlayerInput) {
+export function useScriptVimeoPlayer<T extends VimeoPlayerApi>(_options?: VimeoPlayerInput): T & {
+  $script: Promise<T> & VueScriptInstance<T>
+} {
   const instance = useRegistryScript<T>('vimeoPlayer', () => ({
     scriptInput: {
       src: 'https://player.vimeo.com/api/player.js',

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,6 +1,6 @@
 import { defu } from 'defu'
 import type { BaseSchema, Input, ObjectSchema, ValiError } from 'valibot'
-import type { UseScriptInput } from '@unhead/vue'
+import type { UseScriptInput, VueScriptInstance } from '@unhead/vue'
 import { parse } from '#nuxt-scripts-validator'
 import { useRuntimeConfig, useScript } from '#imports'
 import type {
@@ -34,7 +34,9 @@ export function scriptRuntimeConfig<T extends keyof ScriptRegistry>(key: T) {
   return ((useRuntimeConfig().public.scripts || {}) as ScriptRegistry)[key]
 }
 
-export function useRegistryScript<T extends Record<string | symbol, any>, O extends ObjectSchema<any> = EmptyOptionsSchema>(key: keyof ScriptRegistry | string, optionsFn: OptionsFn<O>, _userOptions?: RegistryScriptInput<O>) {
+export function useRegistryScript<T extends Record<string | symbol, any>, O extends ObjectSchema<any> = EmptyOptionsSchema>(key: keyof ScriptRegistry | string, optionsFn: OptionsFn<O>, _userOptions?: RegistryScriptInput<O>): T & {
+  $script: Promise<T> & VueScriptInstance<T>
+} {
   const scriptConfig = scriptRuntimeConfig(key as keyof ScriptRegistry)
   const userOptions = Object.assign(_userOptions || {}, typeof scriptConfig === 'object' ? scriptConfig : {})
   const options = optionsFn(userOptions)


### PR DESCRIPTION
Currently building nuxt-scripts makes all registry scripts function type return `any` in declaration files. Forcing the return type of `useRgistryScript` fix this issue


fix #72 