### PR TITLE
fix(vimeo): support `url` prop

### DIFF
--- a/src/runtime/components/ScriptVimeoPlayer.vue
+++ b/src/runtime/components/ScriptVimeoPlayer.vue
@@ -12,7 +12,7 @@ const props = withDefaults(defineProps<{
   rootAttrs?: HTMLAttributes
   aboveTheFold?: boolean
   // copied from @types/vimeo__player
-  id: number | undefined
+  id?: number | undefined
   url?: string | undefined
   autopause?: boolean | undefined
   autoplay?: boolean | undefined
@@ -170,8 +170,7 @@ onMounted(() => {
   $script.then(async ({ Vimeo }) => {
     // filter props for false values
     player = new Vimeo.Player(elVimeo.value, {
-      ...props,
-      url: encodeURI(`https://vimeo.com/${props.id}`),
+      ...props
     })
     if (clickTriggered) {
       player!.play()


### PR DESCRIPTION
The user does not always have to provide an ID, but what if a link comes from the API?