### PR TITLE
fix: correct scriptBundling return type

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -117,7 +117,7 @@ export type RegistryScriptInput<T extends ObjectSchema<any> = EmptyOptionsSchema
 
 export interface RegistryScript {
   import?: Import // might just be a component
-  scriptBundling?: false | ((options?: any) => string)
+  scriptBundling?: false | ((options?: any) => string | false)
   label?: string
   src?: string | false
   category?: string


### PR DESCRIPTION
This PR fix the return type of `scriptBundling`