### PR TITLE
chore: fix module option registry type generation

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -21,10 +21,8 @@ import type { NpmInput } from './registry/npm'
 import type { LemonSqueezyInput } from './registry/lemon-squeezy'
 import type { GoogleAdsenseInput } from './registry/google-adsense'
 import type { ClarityInput } from './registry/clarity'
-// @ts-expect-error build-time
-import type { InferInput as GoogleTagManagerInput } from '#build/nuxt-scripts/tpc/google-tag-manager'
-// @ts-expect-error build-time
-import type { InferInput as GoogleAnalyticsInput } from '#build/nuxt-scripts/tpc/google-analytics'
+import type { Input as GoogleTagManagerInput } from '#build/nuxt-scripts/tpc/google-tag-manager'
+import type { Input as GoogleAnalyticsInput } from '#build/nuxt-scripts/tpc/google-analytics'
 
 export type NuxtUseScriptOptions<T = any> = Omit<UseScriptOptions<T>, 'trigger'> & {
   /**

--- a/src/tpc/google-analytics.ts
+++ b/src/tpc/google-analytics.ts
@@ -24,6 +24,7 @@ export default function googleAnalitycsRegistry() {
       })
     },
     filename: 'nuxt-scripts/tpc/google-analytics.ts',
+    write: true,
   })
 
   addImports({

--- a/src/tpc/google-tag-manager.ts
+++ b/src/tpc/google-tag-manager.ts
@@ -25,6 +25,7 @@ export default function googleTagManagerRegistry() {
       })
     },
     filename: 'nuxt-scripts/tpc/google-tag-manager.ts',
+    write: true,
   })
 
   addImports({

--- a/test/types/types.test-d.ts
+++ b/test/types/types.test-d.ts
@@ -1,9 +1,9 @@
-import { describe, expectTypeOf, it } from "vitest"
-import type { ModuleOptions } from "../../dist/module"
-import type { ScriptRegistry } from "../../src/runtime/types"
+import { describe, expectTypeOf, it } from 'vitest'
+import type { ModuleOptions } from '../../dist/module'
+import type { ScriptRegistry } from '../../src/runtime/types'
 
 describe('module options registry', async () => {
-    it('expect no any', async ()  => {
-      expectTypeOf<NonNullable<NonNullable<ModuleOptions>['registry']>[keyof ScriptRegistry]>().not.toBeAny()
-    })
+  it('expect no any', async () => {
+    expectTypeOf<NonNullable<NonNullable<ModuleOptions>['registry']>[keyof ScriptRegistry]>().not.toBeAny()
+  })
 })

--- a/test/types/types.test-d.ts
+++ b/test/types/types.test-d.ts
@@ -1,0 +1,9 @@
+import { describe, expectTypeOf, it } from "vitest"
+import type { ModuleOptions } from "../../dist/module"
+import type { ScriptRegistry } from "../../src/runtime/types"
+
+describe('module options registry', async () => {
+    it('expect no any', async ()  => {
+      expectTypeOf<NonNullable<NonNullable<ModuleOptions>['registry']>[keyof ScriptRegistry]>().not.toBeAny()
+    })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,16 @@
 {
   "extends": "./.nuxt/tsconfig.json",
   "exclude": [
-    "test",
     "docs",
     "playground",
     "client",
     "scripts",
     "dist",
     ".nuxt",
-    ".output"
+    ".output",
+    "test/e2e",
+    "test/fixtures",
+    "test/unit",
+    "test/benchmark.skip.ts"
   ]
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fix the module registry type generation since nuxt-module-builder 0.8. It simply write the generated files and fix some imports

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
