### PR TITLE
chore: drop `postinstall`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest",
     "test:types": "npx nuxi typecheck",
-    "postinstall": "pnpm dev:prepare"
   },
   "build": {
     "externals": [

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest",
-    "test:types": "npx nuxi typecheck",
+    "test:types": "npx nuxi typecheck"
   },
   "build": {
     "externals": [


### PR DESCRIPTION
### 🔗 Linked issue

related nuxt-modules/sitemap#303

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Drop `postinstall` considering that it will also affect Nuxt Scripts.

`postinstall` is added in this commit: 735fdbd9be6792d64221134a91a1f45a819c3179