### PR TITLE
fix: use object syntax to define NuxtConfigScriptRegistry

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -106,9 +106,9 @@ export interface ScriptRegistry {
 }
 
 export type NuxtConfigScriptRegistryEntry<T> = true | 'mock' | T | [T, NuxtUseScriptOptionsSerializable]
-export type NuxtConfigScriptRegistry<T extends keyof ScriptRegistry = keyof ScriptRegistry> = Partial<
-  Record<T, NuxtConfigScriptRegistryEntry<ScriptRegistry[T]>>
->
+export type NuxtConfigScriptRegistry<T extends keyof ScriptRegistry = keyof ScriptRegistry> = Partial<{
+  [key in T]: NuxtConfigScriptRegistryEntry<ScriptRegistry[key]>;
+}>
 
 const emptyOptions = object({})
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fix #92
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR moves NuxtConfigScriptRegistry to Object syntax to correctly loop over ScriptRegistry keys, avoiding it to merge values types when using `Record`

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
