### PR TITLE
fix(tpc): use mlly to resolve third-party-capital

### DIFF
--- a/src/tpc/utils.ts
+++ b/src/tpc/utils.ts
@@ -2,6 +2,7 @@ import type { ExternalScript, Output, Script } from 'third-party-capital'
 import { genImport, genTypeImport } from 'knitwork'
 import { useNuxt } from '@nuxt/kit'
 import type { HeadEntryOptions } from '@unhead/vue'
+import { resolvePath } from 'mlly'
 
 export interface ScriptContentOpts {
   data: Output
@@ -21,7 +22,7 @@ export interface ScriptContentOpts {
 const HEAD_VAR = '__head'
 const INJECTHEAD_CODE = `const ${HEAD_VAR} =  injectHead()`
 
-export function getTpcScriptContent(input: ScriptContentOpts) {
+export async function getTpcScriptContent(input: ScriptContentOpts) {
   const nuxt = useNuxt()
   if (!input.data.scripts)
     throw new Error('input.data has no scripts !')
@@ -46,7 +47,9 @@ export function getTpcScriptContent(input: ScriptContentOpts) {
 
   if (input.tpcTypeImport) {
     // TPC type import
-    imports.add(genTypeImport('third-party-capital', [input.tpcTypeImport]))
+    imports.add(genTypeImport(await resolvePath('third-party-capital', {
+      url: import.meta.url,
+    }), [input.tpcTypeImport]))
   }
 
   if (hasParams) {

--- a/test/unit/tpc.test.ts
+++ b/test/unit/tpc.test.ts
@@ -38,7 +38,7 @@ describe.each([
       scriptFunctionName: 'useScriptGoogleAnalytics',
       use: () => { },
       stub: () => { },
-    })).toThrowError('no main script found for google-analytics in third-party-capital')
+    })).rejects.toThrow('no main script found for google-analytics in third-party-capital')
   })
 
   describe('script content generation', () => {
@@ -68,8 +68,8 @@ describe.each([
       },
     }
 
-    it(`expect to${isDev ? '' : ' not'} add the schema to the script options`, () => {
-      const result = getTpcScriptContent(input)
+    it(`expect to${isDev ? '' : ' not'} add the schema to the script options`, async () => {
+      const result = await getTpcScriptContent(input)
       const returnStatement = getTpcScriptReturnStatement(result, 'useScriptGoogleAnalytics')
       if (!returnStatement || returnStatement.argument?.type !== TSESTree.AST_NODE_TYPES.CallExpression || (returnStatement.argument?.callee as TSESTree.Identifier).name !== 'useRegistryScript') {
         throw new Error('TPC Scripts must return a call expression of useRegistryScript')
@@ -92,8 +92,8 @@ describe.each([
       }
     })
 
-    it('expect to stringify the use and stub functions', () => {
-      const result = getTpcScriptContent(input)
+    it('expect to stringify the use and stub functions', async () => {
+      const result = await getTpcScriptContent(input)
       const returnStatement = getTpcScriptReturnStatement(result, 'useScriptGoogleAnalytics')
       if (!returnStatement || returnStatement.argument?.type !== TSESTree.AST_NODE_TYPES.CallExpression || (returnStatement.argument?.callee as TSESTree.Identifier).name !== 'useRegistryScript') {
         throw new Error('TPC Scripts must return a call expression of useRegistryScript')
@@ -111,8 +111,8 @@ describe.each([
       expect(getCodeFromAst(result, stubFn)).toContain('return []')
     })
 
-    it('expect to augment window types', () => {
-      const result = getTpcScriptContent(input)
+    it('expect to augment window types', async () => {
+      const result = await getTpcScriptContent(input)
       const ast = parse(result, { loc: true, range: true })
       const augmentWindowTypes = ast.body.find((node): node is TSESTree.TSModuleDeclaration => node.type === TSESTree.AST_NODE_TYPES.TSModuleDeclaration)
       expect(augmentWindowTypes).toBeTruthy()
@@ -145,12 +145,12 @@ describe('script content generation with head positioning', () => {
   }
 
   describe('main script', () => {
-    it('main script post body position', () => {
-      const scriptOptsAst = getTpcScriptOptsASt(getTpcScriptContent(inputBase), 'useScriptGoogleAnalytics')
-      expect(getCodeFromAst(getTpcScriptContent(inputBase), scriptOptsAst)).toContain('"tagPosition":"bodyClose"')
+    it('main script post body position', async () => {
+      const scriptOptsAst = getTpcScriptOptsASt(await getTpcScriptContent(inputBase), 'useScriptGoogleAnalytics')
+      expect(getCodeFromAst(await getTpcScriptContent(inputBase), scriptOptsAst)).toContain('"tagPosition":"bodyClose"')
     })
-    it('main script pre body position', () => {
-      const scriptOptsAst = getTpcScriptOptsASt(getTpcScriptContent({
+    it('main script pre body position', async () => {
+      const scriptOptsAst = getTpcScriptOptsASt(await getTpcScriptContent({
         ...inputBase,
         data: {
           ...inputBase.data,
@@ -160,7 +160,7 @@ describe('script content generation with head positioning', () => {
           }],
         },
       }), 'useScriptGoogleAnalytics')
-      expect(getCodeFromAst(getTpcScriptContent(inputBase), scriptOptsAst)).toContain('"tagPosition":"bodyClose"')
+      expect(getCodeFromAst(await getTpcScriptContent(inputBase), scriptOptsAst)).toContain('"tagPosition":"bodyClose"')
     })
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fix #135

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

hey this PR fix an issue with `third-party-capital`. Since tpc composables are generated in .nuxt, we need to resolve the path of third-party-capital from @nuxt/script within the users node_modules as users won't install it.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
