### PR TITLE
fix(tpc): directly push tpc composables into registry

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -141,8 +141,8 @@ export default defineNuxtModule<ModuleOptions>({
 
     const scripts = registry(resolve)
 
-    addGoogleAnalyticsRegistry()
-    addGoogleTagManagerRegistry()
+    addGoogleAnalyticsRegistry(scripts)
+    addGoogleTagManagerRegistry(scripts)
 
     nuxt.hooks.hook('modules:done', async () => {
       const registryScripts = [...scripts]

--- a/src/tpc/google-analytics.ts
+++ b/src/tpc/google-analytics.ts
@@ -1,11 +1,10 @@
-import { addImports, addTemplate, useNuxt } from '@nuxt/kit'
+import { addImports, addTemplate } from '@nuxt/kit'
 import type { Output } from 'third-party-capital'
 import { GooglaAnalyticsData, GoogleAnalytics } from 'third-party-capital'
 import type { RegistryScript } from '../runtime/types'
 import { getTpcScriptContent } from './utils'
 
-export default function googleAnalitycsRegistry() {
-  const nuxt = useNuxt()
+export default function googleAnalitycsRegistry(scripts: RegistryScript[]) {
   const { dst } = addTemplate({
     getContents() {
       return getTpcScriptContent({
@@ -48,7 +47,5 @@ export default function googleAnalitycsRegistry() {
       return false
     },
   }
-  nuxt.hook('scripts:registry', (scripts) => {
-    scripts.push(registry)
-  })
+  scripts.push(registry)
 }

--- a/src/tpc/google-tag-manager.ts
+++ b/src/tpc/google-tag-manager.ts
@@ -1,13 +1,11 @@
-import { addImports, addTemplate, useNuxt } from '@nuxt/kit'
+import { addImports, addTemplate } from '@nuxt/kit'
 import type { Output } from 'third-party-capital'
 import { GoogleTagManager, GoogleTagManagerData } from 'third-party-capital'
 
 import type { RegistryScript } from '../runtime/types'
 import { getTpcScriptContent } from './utils'
 
-export default function googleTagManagerRegistry() {
-  const nuxt = useNuxt()
-
+export default function googleTagManagerRegistry(scripts: RegistryScript[]) {
   const { dst } = addTemplate({
     getContents() {
       return getTpcScriptContent({
@@ -51,7 +49,5 @@ export default function googleTagManagerRegistry() {
     },
   }
 
-  nuxt.hook('scripts:registry', (scripts) => {
-    scripts.push(registry)
-  })
+  scripts.push(registry)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR push tpc composables into the registry array instead of using the hook. Using the hook would make @nuxt/scritps consider tpc composables as new scripts
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
