### PR TITLE
doc: typo for js-confetti getting-started guide

### DIFF
--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -438,7 +438,7 @@ const contributors = useRuntimeConfig().public.contributors
         </template>
         <template #links>
           <div ref="confettiEl">
-            <UButton size="xl" variant="solid" icon="i-ph-sparkle-duotone" color="primary" to="/docs/guides/confetti-tutorial">
+            <UButton size="xl" variant="solid" icon="i-ph-sparkle-duotone" color="primary" to="/docs/getting-started/confetti-tutorial">
               Get started
             </UButton>
           </div>


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The old url was pointing to `/guides`, but it actually resides in `/getting-started`
