### PR TITLE
fix(ScriptYouTubePlayer): missing default slot

### DIFF
--- a/src/runtime/components/ScriptYouTubePlayer.vue
+++ b/src/runtime/components/ScriptYouTubePlayer.vue
@@ -166,5 +166,6 @@ const placeholderAttrs = computed(() => {
     </slot>
     <slot v-if="$script.status.value === 'awaitingLoad'" name="awaitingLoad" />
     <slot v-else-if="$script.status.value === 'error'" name="error" />
+    <slot />
   </div>
 </template>


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The ScriptYouTubePlayer component documentation mentions a default slot that can be used to display content that will always be visible but it is not present in the component. This PR aims to fix that.
