### PR TITLE
chore: update import path for devtools port

### DIFF
--- a/client/bootstrap.ts
+++ b/client/bootstrap.ts
@@ -1,6 +1,6 @@
 import { createResolver, defineNuxtModule } from '@nuxt/kit'
 import { startSubprocess } from '@nuxt/devtools-kit'
-import { DEVTOOLS_UI_LOCAL_PORT } from '../src/devtools'
+import { DEVTOOLS_UI_LOCAL_PORT } from '../src/constants'
 
 const resolver = createResolver(import.meta.url)
 
@@ -11,7 +11,7 @@ export default defineNuxtModule((_, nuxt) => {
   startSubprocess(
     {
       command: 'npx',
-      args: ['nuxi', 'dev', '--port', DEVTOOLS_UI_LOCAL_PORT],
+      args: ['nuxi', 'dev', '--port', DEVTOOLS_UI_LOCAL_PORT.toString()],
       cwd: resolver.resolve('.'),
     },
     {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

This change corrects the import path for `DEVTOOLS_UI_LOCAL_PORT` by referencing it from the constants file.