### PR TITLE
fix(vimeo)!: broken player, refactor props

### DIFF
--- a/docs/content/scripts/content/vimeo-player.md
+++ b/docs/content/scripts/content/vimeo-player.md
@@ -68,10 +68,12 @@ async function play() {
 The `ScriptVimeoPlayer` component accepts the following props:
 
 - `trigger`: The trigger event to load the Vimeo Player. Default is `mousedown`. See [Element Event Triggers](/docs/guides/script-triggers#element-event-triggers) for more information.
-- `placeholderAttrs`: The attributes for the placeholder image. Default is `{ loading: 'lazy' }`.
 - `aboveTheFold`: Optimizes the placeholder image for above-the-fold content. Default is `false`.
-
-All script options from the Player SDK are supported, please consult the [Embed Options](https://developer.vimeo.com/player/sdk/embed)
+- `rootAttrs`: Override the root attributes that are automatically set.
+- `placeholderAttrs`: The attributes for the placeholder image. Default is `{ loading: 'lazy' }`.
+- `id`: Shorthand for `vimeoOptions.id`.
+- `url`: Shorthand for `vimeoOptions.url`.
+- `vimeoOptions`: All options from the Player SDK are supported, please consult the [Embed Options](https://developer.vimeo.com/player/sdk/embed)
 for full documentation.
 
 ```ts

--- a/playground/pages/third-parties/vimeo/nuxt-scripts.vue
+++ b/playground/pages/third-parties/vimeo/nuxt-scripts.vue
@@ -13,6 +13,7 @@ function changeVideo() {
     <ScriptVimeoPlayer
       :id="videoid"
       above-the-fold
+      class="w-[900px] w-[100%] h-[700px]"
     />
     <UButton
       class="mt-5"

--- a/src/runtime/components/ScriptVimeoPlayer.vue
+++ b/src/runtime/components/ScriptVimeoPlayer.vue
@@ -142,12 +142,16 @@ if (import.meta.server) {
   })
 }
 
+const id = computed(() => {
+  return props.vimeoOptions?.id || props.id
+})
+
 const { data: payload } = useAsyncData(
-  `vimeo-embed:${props.id}`,
+  `vimeo-embed:${id.value}`,
   // TODO ideally we cache this
-  () => $fetch(`https://vimeo.com/api/v2/video/${props.id}.json`).then(res => (res as any)[0]),
+  () => $fetch(`https://vimeo.com/api/v2/video/${id.value}.json`).then(res => (res as any)[0]),
   {
-    watch: [() => props.id],
+    watch: [id],
   },
 )
 
@@ -181,13 +185,13 @@ const height = computed(() => {
 
 onMounted(() => {
   onLoaded(async ({ Vimeo }) => {
-    const vimeoOptions: VimeoOptions = defu(props.vimeoOptions, {
-      id: props.id,
-      url: props.url,
-    })
-    // width: props.width || elVimeo.value.parentNode.offsetWidth,
-    // height: props.height || elVimeo.value.parentNode.offsetHeight,
-    // filter props for false values
+    const vimeoOptions = props.vimeoOptions || {}
+    if (!vimeoOptions.id) {
+      vimeoOptions.id = props.id
+    }
+    if (!vimeoOptions.url) {
+      vimeoOptions.url = props.url
+    }
     player = new Vimeo.Player(elVimeo.value, vimeoOptions)
     if (clickTriggered) {
       player!.play()

--- a/src/runtime/components/ScriptVimeoPlayer.vue
+++ b/src/runtime/components/ScriptVimeoPlayer.vue
@@ -176,22 +176,24 @@ defineExpose({
 })
 
 const width = computed(() => {
-  return props.vimeoOptions?.width || elVimeo.value.parentNode?.offsetWidth || 640
+  return props.vimeoOptions?.width || elVimeo.value?.parentNode?.offsetWidth || 640
 })
 
 const height = computed(() => {
-  return props.vimeoOptions?.height || elVimeo.value.parentNode?.offsetHeight || 480
+  return props.vimeoOptions?.height || elVimeo.value?.parentNode?.offsetHeight || 480
 })
 
 onMounted(() => {
   onLoaded(async ({ Vimeo }) => {
     const vimeoOptions = props.vimeoOptions || {}
-    if (!vimeoOptions.id) {
+    if (!vimeoOptions.id && props.id) {
       vimeoOptions.id = props.id
     }
-    if (!vimeoOptions.url) {
+    if (!vimeoOptions.url && props.url) {
       vimeoOptions.url = props.url
     }
+    vimeoOptions.width = width.value
+    vimeoOptions.height = height.value
     player = new Vimeo.Player(elVimeo.value, vimeoOptions)
     if (clickTriggered) {
       player!.play()
@@ -233,8 +235,8 @@ const rootAttrs = computed(() => {
     'style': {
       maxWidth: '100%',
       width: `${width.value}px`,
-      height: `'auto'`,
-      aspectRatio: `${width.value}/${height.value}`,
+      height: 'auto',
+      aspectRatio: `16/9`,
       position: 'relative',
       backgroundColor: 'black',
     },
@@ -262,7 +264,7 @@ onBeforeUnmount(() => player?.unload())
 
 <template>
   <div ref="rootEl" v-bind="rootAttrs">
-    <div v-show="ready" ref="elVimeo" class="vimeo-player" style="width: 100%; height: 100%; max-width: 100%;" />
+    <div v-show="ready" ref="elVimeo" class="vimeo-player" />
     <slot v-if="!ready" v-bind="payload" :placeholder="placeholder" name="placeholder">
       <img v-if="placeholder" v-bind="placeholderAttrs">
     </slot>
@@ -277,6 +279,9 @@ onBeforeUnmount(() => player?.unload())
 
 <style>
 .vimeo-player iframe {
+  height: auto;
+  aspect-ratio: 16/9;
+  width: 100%;
   max-width: 100% !important;
 }
 </style>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vimeo player is not working because the prop merging is buggy. To solve this, the easiest way that is future-proof is to add the `vimeoOptions` to the props.

For convenience and to lessen the breaking changes, we accept an `id` or an `url` top level as well.

While modifying this, we also prefer automatic height based on the parent container.

⚠️ This is a breaking change for anyone using the vimeo options as root level props and may style differently.



<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
