### PR TITLE
refactor(playground): avoid deprecated useScript api

### DIFF
--- a/playground/pages/features/on-nuxt-ready.vue
+++ b/playground/pages/features/on-nuxt-ready.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useScriptGoogleTagManager } from '#imports'
 
-const { $script } = useScriptGoogleTagManager({
+const { status } = useScriptGoogleTagManager({
   id: 'GTM-5ZQZJZ',
   scriptOptions: {
     trigger: 'onNuxtReady', // this is the default behavior
@@ -13,7 +13,7 @@ const { $script } = useScriptGoogleTagManager({
 <template>
   <div>
     <div>
-      {{ $script.status.value }}
+      {{ status }}
     </div>
   </div>
 </template>

--- a/playground/pages/npm/js-confetti.vue
+++ b/playground/pages/npm/js-confetti.vue
@@ -14,7 +14,7 @@ declare global {
   type Window = JSConfettiApi
 }
 
-const { $script } = useScriptNpm<JSConfettiApi>({
+const { then } = useScriptNpm<JSConfettiApi>({
   packageName: 'js-confetti',
   file: 'dist/js-confetti.browser.js',
   version: '0.12.0',
@@ -27,7 +27,7 @@ const { $script } = useScriptNpm<JSConfettiApi>({
 })
 
 function addConfetti(options: { emojis: string[] }) {
-  $script.then(({ JSConfetti }) => {
+  then(({ JSConfetti }) => {
     const confetti = new JSConfetti()
     confetti.addConfetti(options)
   })

--- a/playground/pages/third-parties/clarity/nuxt-scripts.vue
+++ b/playground/pages/third-parties/clarity/nuxt-scripts.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Clarity',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { $script } = useScriptClarity({
+// composables return the underlying api as a proxy object and the script state
+const { status } = useScriptClarity({
   id: 'mqk2m9dr2v',
 })
 </script>
@@ -15,7 +15,7 @@ const { $script } = useScriptClarity({
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status }}
+        status: {{ status }}
       </div>
     </ClientOnly>
   </div>

--- a/playground/pages/third-parties/cloudflare-web-analytics/nuxt-scripts.vue
+++ b/playground/pages/third-parties/cloudflare-web-analytics/nuxt-scripts.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Cloudflare Web Analytics',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { $script } = useScriptCloudflareWebAnalytics({
+// composables return the underlying api as a proxy object and the script state
+const { status } = useScriptCloudflareWebAnalytics({
   token: 'ade278253a19413c9bd923b079870902',
 })
 </script>
@@ -15,7 +15,7 @@ const { $script } = useScriptCloudflareWebAnalytics({
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status }}
+        status: {{ status }}
       </div>
     </ClientOnly>
   </div>

--- a/playground/pages/third-parties/fathom-analytics.vue
+++ b/playground/pages/third-parties/fathom-analytics.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Fathom',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { $script, trackPageview, trackEvent } = useScriptFathomAnalytics({
+// composables return the underlying api as a proxy object and the script state
+const { status, trackPageview, trackEvent } = useScriptFathomAnalytics({
   site: 'BRDEJWKJ',
 })
 // this will be triggered once the script is ready async
@@ -26,7 +26,7 @@ async function clickHandler() {
     </UButton>
     <ClientOnly>
       <div>
-        status: {{ $script.status.value }}
+        status: {{ status }}
       </div>
     </ClientOnly>
   </div>

--- a/playground/pages/third-parties/google-adsense/unhead.vue
+++ b/playground/pages/third-parties/google-adsense/unhead.vue
@@ -5,7 +5,6 @@ useHead({
   title: 'Google Adsense',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
 useHead({
   script: [
     {

--- a/playground/pages/third-parties/google-analytics/multiple.vue
+++ b/playground/pages/third-parties/google-analytics/multiple.vue
@@ -5,13 +5,13 @@ useHead({
   title: 'Google Analytics',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { gtag: gtag1, $script: $script1 } = useScriptGoogleAnalytics({
+// composables return the underlying api as a proxy object and the script state
+const { gtag: gtag1, status: status1 } = useScriptGoogleAnalytics({
   key: 'gtag1',
   id: 'G-TR58L0EF8P',
 })
 
-const { gtag: gtag2, $script: $script2 } = useScriptGoogleAnalytics({
+const { gtag: gtag2, status: status2 } = useScriptGoogleAnalytics({
   key: 'gtag2',
   id: 'G-1234567890',
 })
@@ -32,12 +32,12 @@ function triggerConversion() {
   <div>
     <ClientOnly>
       <div>
-        1 status: {{ $script1.status.value }}
+        1 status: {{ status1 }}
       </div>
     </ClientOnly>
     <ClientOnly>
       <div>
-        2 status: {{ $script2.status.value }}
+        2 status: {{ status2 }}
       </div>
     </ClientOnly>
     <button @click="triggerConversion">

--- a/playground/pages/third-parties/google-analytics/nuxt-scripts.vue
+++ b/playground/pages/third-parties/google-analytics/nuxt-scripts.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Google Analytics',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { gtag, $script } = useScriptGoogleAnalytics({
+// composables return the underlying api as a proxy object and the script state
+const { gtag, status } = useScriptGoogleAnalytics({
   id: 'G-TR58L0EF8P',
 }) // id set via nuxt scripts module config
 gtag('event', 'page_view', {
@@ -24,7 +24,7 @@ function triggerConversion() {
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status.value }}
+        status: {{ status }}
       </div>
     </ClientOnly>
     <button @click="triggerConversion">

--- a/playground/pages/third-parties/google-tag-manager.vue
+++ b/playground/pages/third-parties/google-tag-manager.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Google Analytics',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { dataLayer, $script } = useScriptGoogleTagManager({
+// composables return the underlying api as a proxy object and the script state
+const { dataLayer, then, status } = useScriptGoogleTagManager({
   id: 'GTM-MNJD4B',
 }) // id is set via runtime config
 dataLayer.push({
@@ -15,7 +15,7 @@ dataLayer.push({
   page_location: 'https://harlanzw.com/third-parties/google-analytics',
   page_path: '/third-parties/google-analytics',
 })
-$script.then(({ google_tag_manager, dataLayer }) => {
+then(({ google_tag_manager, dataLayer }) => {
   // eslint-disable-next-line no-console
   console.log('google_tag_manager is ready', google_tag_manager)
   // eslint-disable-next-line no-console
@@ -39,7 +39,7 @@ $script.then(({ google_tag_manager, dataLayer }) => {
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status }}
+        status: {{ status }}
       </div>
     </ClientOnly>
   </div>

--- a/playground/pages/third-parties/hotjar.vue
+++ b/playground/pages/third-parties/hotjar.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Hotjar',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { $script, hj } = useScriptHotjar({ id: 3925006, sv: 6 })
+// composables return the underlying api as a proxy object and the script state
+const { status, hj } = useScriptHotjar({ id: 3925006, sv: 6 })
 // this will be triggered once the script is ready async
 hj('identify', '123456', { test: 'foo' })
 </script>
@@ -15,7 +15,7 @@ hj('identify', '123456', { test: 'foo' })
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status }}
+        status: {{ status }}
       </div>
     </ClientOnly>
   </div>

--- a/playground/pages/third-parties/intercom/use-script.vue
+++ b/playground/pages/third-parties/intercom/use-script.vue
@@ -5,16 +5,16 @@ useHead({
   title: 'Intercom',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
+// composables return the underlying api as a proxy object and the script state
 const instance = useScriptIntercom({ app_id: 'nu034r2a' })
-const { $script, Intercom } = instance
+const { status, Intercom } = instance
 </script>
 
 <template>
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status }}
+        status: {{ status }}
       </div>
       <div>
         <button @click="Intercom('show')">

--- a/playground/pages/third-parties/matomo-analytics.vue
+++ b/playground/pages/third-parties/matomo-analytics.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Matomo Analytics',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { $script, _paq } = useScriptMatomoAnalytics({
+// composables return the underlying api as a proxy object and the script state
+const { status, _paq } = useScriptMatomoAnalytics({
   matomoUrl: 'https://nuxt-scripts-demo.matomo.cloud',
   siteId: '1',
 })
@@ -18,7 +18,7 @@ _paq.push(['trackPageView'])
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status.value }}
+        status: {{ status }}
       </div>
     </ClientOnly>
   </div>

--- a/playground/pages/third-parties/meta-pixel.vue
+++ b/playground/pages/third-parties/meta-pixel.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Meta Pixel',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { $script, fbq } = useScriptMetaPixel({ id: '3925006' })
+// composables return the underlying api as a proxy object and the script state
+const { status, fbq } = useScriptMetaPixel({ id: '3925006' })
 // this will be triggered once the script is ready async
 function triggerEvent() {
   fbq('track', 'ViewContent', {
@@ -20,7 +20,7 @@ function triggerEvent() {
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status }}
+        status: {{ status }}
       </div>
       <button @click="triggerEvent">
         Trigger Event

--- a/playground/pages/third-parties/plausible-analytics.vue
+++ b/playground/pages/third-parties/plausible-analytics.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Plausible',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { $script, plausible } = useScriptPlausibleAnalytics({
+// composables return the underlying api as a proxy object and the script state
+const { status, plausible } = useScriptPlausibleAnalytics({
   domain: 'scripts.nuxt.com',
   extension: 'local',
 })
@@ -27,7 +27,7 @@ async function clickHandler() {
     </UButton>
     <ClientOnly>
       <div>
-        status: {{ $script.status.value }}
+        status: {{ status }}
       </div>
     </ClientOnly>
   </div>

--- a/playground/pages/third-parties/segment.vue
+++ b/playground/pages/third-parties/segment.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'Segment',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { page, $script } = useScriptSegment({ writeKey: 'KBXOGxgqMFjm2mxtJDJg0iDn5AnGYb9C' })
+// composables return the underlying api as a proxy object and the script state
+const { page, status } = useScriptSegment({ writeKey: 'KBXOGxgqMFjm2mxtJDJg0iDn5AnGYb9C' })
 
 page('Segment')
 </script>
@@ -15,7 +15,7 @@ page('Segment')
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status.value }}
+        status: {{ status }}
       </div>
     </ClientOnly>
   </div>

--- a/playground/pages/third-parties/x-pixel/nuxt-scripts.vue
+++ b/playground/pages/third-parties/x-pixel/nuxt-scripts.vue
@@ -5,8 +5,8 @@ useHead({
   title: 'X Pixel',
 })
 
-// composables return the underlying api as a proxy object and a $script with the script state
-const { $script, twq } = useScriptXPixel({ id: 'ol7lz' })
+// composables return the underlying api as a proxy object and the script state
+const { status, twq } = useScriptXPixel({ id: 'ol7lz' })
 // this will be triggered once the script is ready async
 function triggerEvent() {
   twq('event', 'tw-ol7lz-ol7mb', {
@@ -19,7 +19,7 @@ function triggerEvent() {
   <div>
     <ClientOnly>
       <div>
-        status: {{ $script.status }}
+        status: {{ status }}
       </div>
       <UButton @click="triggerEvent">
         Trigger Event


### PR DESCRIPTION
### 🔗 Linked issue

Relate to this unhead [PR](https://github.com/unjs/unhead/pull/379#issue-2470480475) and this [tag](https://github.com/nuxt/scripts/blob/main/src/runtime/composables/useScript.ts#L19-L21)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Reduce the deprecated way of using script instance functions in the playground domain.
