### PR TITLE
chore(docs): fix incorrect links

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation.md
+++ b/docs/content/docs/1.getting-started/2.installation.md
@@ -18,7 +18,7 @@ That's it! The Nuxt Scripts module should be downloaded and added to your Nuxt C
 Need some inspiration to start using Nuxt Scripts? Try out the following:
 
 1. 🎉 Make it rain emojis with the [Confetti Tutorial](/docs/getting-started/confetti-tutorial).
-2. 📚 Learn about how the [Script Loading](/docs/guides/script-loading) works.
+2. 📚 Learn about how the [Script Loading](/docs/guides/script-triggers) works.
 3. 🔍 Explore the [Script Registry](/scripts) for popular pre-configured third-party scripts.
 3. 🚀 Load other scripts with [useScript](/docs/api/use-script) or [Global Scripts](/docs/guides/global).
 4. 🔨 Fine-tune your performance and privacy with [Bundling](/docs/guides/bundling) and [Consent Management](/docs/guides/consent).

--- a/docs/content/docs/1.getting-started/3.confetti-tutorial.md
+++ b/docs/content/docs/1.getting-started/3.confetti-tutorial.md
@@ -11,7 +11,7 @@ You'll learn about the following:
 - What the `useScriptNpm` registry script is.
 - How to load the `js-confetti` script using it.
 - Adding types to loaded scripts.
-- Using proxied functions to call the script.
+- Using [proxied functions](/docs/guides/key-concepts#understanding-proxied-functions) to call the script.
 
 ## Background on useScriptNpm
 
@@ -104,7 +104,7 @@ Now that we have a way to resolve the third-party script API, we can start using
 The `js-confetti` library requires us to instantiate a new instance of the `JSConfetti` class everytime it's used,
 the most compatible way to handle this is to wait for the script to load explicitly.
 
-However, we can also make use of [proxied functions](/docs/guides/script-loading#Understanding-proxied-functions) if we prefer an easier to use API. Note that this will break
+However, we can also make use of [proxied functions](docs/guides/key-concepts#understanding-proxied-functions) if we prefer an easier to use API. Note that this will break
 when switching between pages as `new window.JSConfetti()` needs to be called between pages.
 
 ::code-group

--- a/docs/content/docs/1.getting-started/3.confetti-tutorial.md
+++ b/docs/content/docs/1.getting-started/3.confetti-tutorial.md
@@ -104,7 +104,7 @@ Now that we have a way to resolve the third-party script API, we can start using
 The `js-confetti` library requires us to instantiate a new instance of the `JSConfetti` class everytime it's used,
 the most compatible way to handle this is to wait for the script to load explicitly.
 
-However, we can also make use of [proxied functions](docs/guides/key-concepts#understanding-proxied-functions) if we prefer an easier to use API. Note that this will break
+However, we can also make use of [proxied functions](/docs/guides/key-concepts#understanding-proxied-functions) if we prefer an easier to use API. Note that this will break
 when switching between pages as `new window.JSConfetti()` needs to be called between pages.
 
 ::code-group


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- The text `Script Loading` points to a invalid link, and I guess, author meant to point to [this page](https://scripts.nuxt.com/docs/guides/script-triggers).
- The text `proxied functions` should point to [this page](https://scripts.nuxt.com/docs/guides/key-concepts#understanding-proxied-functions)
