### PR TITLE
fix(adsense)!: remove default `data-ad-format`

### DIFF
--- a/src/runtime/components/ScriptGoogleAdsense.vue
+++ b/src/runtime/components/ScriptGoogleAdsense.vue
@@ -14,7 +14,6 @@ const props = withDefaults(defineProps<{
    */
   trigger?: ElementScriptTrigger
 }>(), {
-  dataAdFormat: 'auto',
   dataFullWidthResponsive: true,
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #247

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Removed the default ad format, allowing for fixed-size ad units