### PR TITLE
docs: update scripts:registry hook example

### DIFF
--- a/docs/content/docs/3.api/6.nuxt-hooks.md
+++ b/docs/content/docs/3.api/6.nuxt-hooks.md
@@ -5,7 +5,7 @@ description: Use Nuxt hooks to extend the Nuxt Scripts module.
 
 ## `scripts:registry`
 
-- Type: `async ({ registry: ScriptRegistry }) => HookResult`
+- Type: `async (registry: RegistryScripts) => HookResult`
 
 Add registry scripts at build, allowing them to be loaded via `scripts.registry` and bundled if available.
 

--- a/docs/content/docs/3.api/6.nuxt-hooks.md
+++ b/docs/content/docs/3.api/6.nuxt-hooks.md
@@ -5,7 +5,7 @@ description: Use Nuxt hooks to extend the Nuxt Scripts module.
 
 ## `scripts:registry`
 
-- Type: `async (ctx: { registry: ScriptRegistry }) => HookResult`
+- Type: `async ({ registry: ScriptRegistry }) => HookResult`
 
 Add registry scripts at build, allowing them to be loaded via `scripts.registry` and bundled if available.
 
@@ -14,8 +14,8 @@ This is intended to be used by modules.
 ```ts [module.ts]
 export default defineNuxtModule({
   setup() {
-    nuxt.hooks.hook('scripts:registry', async (ctx) => {
-      ctx.registry.add({
+    nuxt.hooks.hook('scripts:registry', async (registry) => {
+      registry.push({
         // used in DevTools
         label: 'My Custom Script',
         logo: `<svg class="w-10 h-10" xmlns="http://www.w3.org/2000/svg" width="28.85" height="32" viewBox="0 0 256 284"><path fill="#F9AB00" d="M256.003 247.933a35.224 35.224 0 0 1-39.376 35.161c-18.044-2.67-31.266-18.371-30.826-36.606V36.845C185.365 18.591 198.62 2.881 216.687.24a35.221 35.221 0 0 1 39.316 35.16z"/><path fill="#E37400" d="M35.101 213.193c19.386 0 35.101 15.716 35.101 35.101c0 19.386-15.715 35.101-35.101 35.101S0 267.68 0 248.295c0-19.386 15.715-35.102 35.101-35.102m92.358-106.387c-19.477 1.068-34.59 17.406-34.137 36.908v94.285c0 25.588 11.259 41.122 27.755 44.433a35.161 35.161 0 0 0 42.146-34.56V142.089a35.222 35.222 0 0 0-35.764-35.282"/></svg>`,


### PR DESCRIPTION
docs: update script:registry hook example

### 🔗 Linked issue

Resolves #267 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The example in the docs on how to extend registry scripts via `scripts:registry` is not working. I updated it with a working example.

see #267 
