### PR TITLE
fix: :bug: Fixed "height" css style property

### DIFF
--- a/src/runtime/components/ScriptYouTubePlayer.vue
+++ b/src/runtime/components/ScriptYouTubePlayer.vue
@@ -116,7 +116,7 @@ const rootAttrs = computed(() => {
       backgroundColor: 'black',
       maxWidth: '100%',
       width: `${props.width}px`,
-      height: `'auto'`,
+      height: 'auto',
       aspectRatio: `${props.width}/${props.height}`,
     },
     ...(trigger instanceof Promise ? trigger.ssrAttrs || {} : {}),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Removed the backticks that makes the "height" prop invalid for CSS.

<img width="220" alt="Screenshot 2024-09-19 at 18 28 56" src="https://github.com/user-attachments/assets/9c5d9248-6eae-4fb9-b689-15fbe92c5ef4">


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
