### PR TITLE
fix(adsense): push ad slot once only on dev

### DIFF
--- a/src/runtime/components/ScriptGoogleAdsense.vue
+++ b/src/runtime/components/ScriptGoogleAdsense.vue
@@ -35,10 +35,18 @@ const instance = useScriptGoogleAdsense({
 
 const { status } = instance
 
+function pushAdSlot() {
+  (window.adsbygoogle = window.adsbygoogle || []).push({})
+}
+
 onMounted(() => {
-  callOnce(() => {
-    (window.adsbygoogle = window.adsbygoogle || []).push({})
-  })
+  if (import.meta.dev) {
+    callOnce(() => pushAdSlot())
+  }
+  else {
+    pushAdSlot()
+  }
+
   watch(status, (val) => {
     if (val === 'loaded') {
       emits('ready', instance)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow multiple ad slots to be pushed in production, but call once only in dev  because HMR triggers new ad to be pushed each time