### PR TITLE
docs: fix docs for disabling scripts in development

### DIFF
--- a/docs/content/docs/1.guides/1.registry-scripts.md
+++ b/docs/content/docs/1.guides/1.registry-scripts.md
@@ -98,14 +98,17 @@ You can do this by providing a `mock` value to the registry script.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
-  $production: {
+  scripts: {
+    registry: {
+      googleTagManager: true,
+    },
+  },
+  $development: {
     scripts: {
       registry: {
-        googleAnalytics: {
-          id: 'YOUR_ID',
-        },
-      }
-    }
+        googleTagManager: "mock",
+      },
+    },
   },
 })
 ```


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The description of disabling nuxt scripts in development provided the information about using `mock`. The snippet on the other hand did not use `mock`. This was introduced in 253085d1c79403d65d17f50f48d4874e0a714448.