### PR TITLE
fix: optional Valibot schema

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -140,7 +140,7 @@ type ScriptInput = ScriptBase & DataKeys & SchemaAugmentations['script']
 
 export type InferIfSchema<T> = T extends ObjectSchema<any, any> ? InferInput<T> : T
 export type RegistryScriptInput<
-  T,
+  T = EmptyOptionsSchema,
   Bundelable extends boolean = true,
   Usable extends boolean = false,
   CanBypassOptions extends boolean = true,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -138,13 +138,14 @@ export type EmptyOptionsSchema = typeof _emptyOptions
 
 type ScriptInput = ScriptBase & DataKeys & SchemaAugmentations['script']
 
+export type InferIfSchema<T> = T extends ObjectSchema<any, any> ? InferInput<T> : T
 export type RegistryScriptInput<
-  T extends ObjectSchema<any, any> = EmptyOptionsSchema,
+  T,
   Bundelable extends boolean = true,
   Usable extends boolean = false,
   CanBypassOptions extends boolean = true,
 > =
-    (InferInput<T>
+    (InferIfSchema<T>
       & {
       /**
        * A unique key to use for the script, this can be used to load multiple of the same script with different options.
@@ -153,7 +154,7 @@ export type RegistryScriptInput<
         scriptInput?: ScriptInput
         scriptOptions?: Omit<NuxtUseScriptOptions, Bundelable extends true ? '' : 'bundle' | Usable extends true ? '' : 'use'>
       })
-      | Partial<InferInput<T>> & (
+      | Partial<InferIfSchema<T>> & (
       CanBypassOptions extends true ? {
       /**
        * A unique key to use for the script, this can be used to load multiple of the same script with different options.

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -6,6 +6,7 @@ import { parse } from '#nuxt-scripts-validator'
 import { useRuntimeConfig } from '#imports'
 import type {
   EmptyOptionsSchema,
+  InferIfSchema,
   NuxtUseScriptOptions,
   RegistryScriptInput,
   ScriptRegistry,
@@ -27,7 +28,7 @@ function validateScriptInputSchema<T extends GenericSchema>(key: string, schema:
   }
 }
 
-type OptionsFn<O> = (options: O) => ({
+type OptionsFn<O> = (options: InferIfSchema<O>) => ({
   scriptInput?: UseScriptInput
   scriptOptions?: NuxtUseScriptOptions
   schema?: O extends ObjectSchema<any, any> ? O : undefined

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -27,10 +27,10 @@ function validateScriptInputSchema<T extends GenericSchema>(key: string, schema:
   }
 }
 
-type OptionsFn<O extends ObjectSchema<any, any>> = (options: InferInput<O>) => ({
+type OptionsFn<O> = (options: O) => ({
   scriptInput?: UseScriptInput
   scriptOptions?: NuxtUseScriptOptions
-  schema?: O
+  schema?: O extends ObjectSchema<any, any> ? O : undefined
   clientInit?: () => void
 })
 
@@ -38,7 +38,7 @@ export function scriptRuntimeConfig<T extends keyof ScriptRegistry>(key: T) {
   return ((useRuntimeConfig().public.scripts || {}) as ScriptRegistry)[key]
 }
 
-export function useRegistryScript<T extends Record<string | symbol, any>, O extends ObjectSchema<any, any> = EmptyOptionsSchema, U = {}>(registryKey: keyof ScriptRegistry | string, optionsFn: OptionsFn<O>, _userOptions?: RegistryScriptInput<O>) {
+export function useRegistryScript<T extends Record<string | symbol, any>, O = EmptyOptionsSchema, U = {}>(registryKey: keyof ScriptRegistry | string, optionsFn: OptionsFn<O>, _userOptions?: RegistryScriptInput<O>) {
   const scriptConfig = scriptRuntimeConfig(registryKey as keyof ScriptRegistry)
   const userOptions = Object.assign(_userOptions || {}, typeof scriptConfig === 'object' ? scriptConfig : {})
   const options = optionsFn(userOptions)

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -42,7 +42,7 @@ export function scriptRuntimeConfig<T extends keyof ScriptRegistry>(key: T) {
 export function useRegistryScript<T extends Record<string | symbol, any>, O = EmptyOptionsSchema, U = {}>(registryKey: keyof ScriptRegistry | string, optionsFn: OptionsFn<O>, _userOptions?: RegistryScriptInput<O>) {
   const scriptConfig = scriptRuntimeConfig(registryKey as keyof ScriptRegistry)
   const userOptions = Object.assign(_userOptions || {}, typeof scriptConfig === 'object' ? scriptConfig : {})
-  const options = optionsFn(userOptions)
+  const options = optionsFn(userOptions as InferIfSchema<O>)
 
   const scriptInput = defu(userOptions.scriptInput, options.scriptInput, { key: registryKey }) as any as UseScriptInput
   const scriptOptions = Object.assign(userOptions?.scriptOptions || {}, options.scriptOptions || {})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

@harlan-zw following the discord discussion, this could be a first solution for TPC V3. This would allow to have typesafety but without runtime validation so we don't have to know how TPC or any other type is defined but passing it as a Type Parameter would be enough to warn devs that something is wrong

cc @flashdesignory 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
