### PR TITLE
feat: Adjust YouTube thumbnail ratio to 640x360

### DIFF
--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import { useScriptsRegistry } from '~/composables/useScriptsRegistry'
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 
+const breakpoints = useBreakpoints(breakpointsTailwind)
 const registry = useScriptsRegistry()
+
+const btnGroupOrientation = computed(() => breakpoints.smaller('sm').value ? 'vertical' : 'horizontal')
 
 useSeoMeta({
   title: 'Third-Party Scripts Meets Nuxt DX.',
@@ -211,7 +215,7 @@ function timesFaster(nuxt: number, iframe: number) {
       </ul>
     </ULandingSection>
 
-    <div class="py-6 sm:py-20 gap-20 mb-12 flex flex-col xl:flex-row items-center max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <UContainer class="py-6 sm:py-20 gap-20 mb-12 flex flex-col xl:flex-row items-center">
       <div class="max-w-lg">
         <h2 class="text-xl xl:text-4xl font-bold flex items-center gap-4 mb-4">
           <UIcon name="i-ph-speedometer-duotone" class="h-12 w-12 shrink-0 text-primary" />
@@ -226,7 +230,7 @@ function timesFaster(nuxt: number, iframe: number) {
         <p class="text-gray-500 dark:text-gray-400">
           <span class="opacity-50 text-sm">*Benchmarks are from pagespeed.web.dev Mobile report running with variability, they are not accurate.</span>
         </p>
-        <UButtonGroup class="mt-10 flex flex-col sm:flex-row">
+        <UButtonGroup class="mt-10 flex" :orientation="btnGroupOrientation">
           <UButton :variant="webVital === 'fcp' ? 'solid' : 'soft'" :active="webVital === 'fcp'" @click="webVital = 'fcp'">
             First Contentful Paint
           </UButton>
@@ -272,7 +276,7 @@ function timesFaster(nuxt: number, iframe: number) {
           </div>
         </div>
       </div>
-    </div>
+    </UContainer>
   </div>
 </template>
 

--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -211,7 +211,7 @@ function timesFaster(nuxt: number, iframe: number) {
       </ul>
     </ULandingSection>
 
-    <div class="py-6 sm:py-20 gap-20 mb-12 flex flex-col xl:flex-row items-center max-w-7xl mx-auto">
+    <div class="py-6 sm:py-20 gap-20 mb-12 flex flex-col xl:flex-row items-center max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="max-w-lg">
         <h2 class="text-xl xl:text-4xl font-bold flex items-center gap-4 mb-4">
           <UIcon name="i-ph-speedometer-duotone" class="h-12 w-12 shrink-0 text-primary" />
@@ -226,7 +226,7 @@ function timesFaster(nuxt: number, iframe: number) {
         <p class="text-gray-500 dark:text-gray-400">
           <span class="opacity-50 text-sm">*Benchmarks are from pagespeed.web.dev Mobile report running with variability, they are not accurate.</span>
         </p>
-        <UButtonGroup class="mt-10 flex flex-col md:flex-row">
+        <UButtonGroup class="mt-10 flex flex-col sm:flex-row">
           <UButton :variant="webVital === 'fcp' ? 'solid' : 'soft'" :active="webVital === 'fcp'" @click="webVital = 'fcp'">
             First Contentful Paint
           </UButton>

--- a/src/runtime/components/ScriptYouTubePlayer.vue
+++ b/src/runtime/components/ScriptYouTubePlayer.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<{
   // @ts-expect-error untyped
   playerVars: { autoplay: 0, playsinline: 1 },
   width: 640,
-  height: 480,
+  height: 360,
 })
 
 const emits = defineEmits<{
@@ -139,7 +139,7 @@ const placeholderAttrs = computed(() => {
     loading: props.aboveTheFold ? 'eager' : 'lazy',
     style: {
       width: '100%',
-      objectFit: 'contain',
+      objectFit: 'cover',
       height: '100%',
     },
   } satisfies ImgHTMLAttributes)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->


<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

This MR updates the default thumbnail format for YouTube videos to 640x360 (16:9), removing black bars that appeared in the previous `sddefault` preview (640x480), due to an incorrect aspect ratio.

#### Main Changes:
- **Default Format**: Changed from 640x480 to 640x360 to maintain a 16:9 aspect ratio. https://support.google.com/youtube/answer/6375112
- **Removal of Black Bars**: The new format displays thumbnails without the black bars at the top and bottom, providing a cleaner and more immersive preview.

#### Impact:
- Front-end thumbnails will now adhere to the standard 16:9 aspect ratio, improving visual consistency and aesthetic appeal.
