### PR TITLE
docs: fix inconsistent example env keys

### DIFF
--- a/docs/content/docs/1.guides/1.registry-scripts.md
+++ b/docs/content/docs/1.guides/1.registry-scripts.md
@@ -61,7 +61,7 @@ Registry scripts can be configured through your `.env` file, allowing you to pro
 ::code-group
 
 ```text [.env]
-NUXT_SCRIPTS_CLOUDFLARE_WEB_ANALYTICS=YOUR_TOKEN
+NUXT_PUBLIC_SCRIPTS_CLOUDFLARE_WEB_ANALYTICS_TOKEN=YOUR_TOKEN
 ```
 
 ```ts [nuxt.config.ts]
@@ -77,7 +77,7 @@ export default defineNuxtConfig({
       scripts: {
         cloudflareWebAnalytics: {
           // provide empty string so .env works
-          token: '', // NUXT_SCRIPTS_CLOUDFLARE_WEB_ANALYTICS_TOKEN
+          token: '', // NUXT_PUBLIC_SCRIPTS_CLOUDFLARE_WEB_ANALYTICS_TOKEN
         },
       },
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I am new to nuxt script, and after reading the docs I still have no idea how to config a registry script with env. There were like 3 different versions of key names for a same example


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
