### PR TITLE
fix(YoutubePlayer,VimeoPlayer)!: auto width for responsive design on mobile devices

### DIFF
--- a/src/runtime/components/ScriptVimeoPlayer.vue
+++ b/src/runtime/components/ScriptVimeoPlayer.vue
@@ -237,7 +237,7 @@ const rootAttrs = computed(() => {
     'role': 'application',
     'style': {
       maxWidth: '100%',
-      width: `${width.value}px`,
+      width: `auto`,
       height: 'auto',
       aspectRatio: `16/9`,
       position: 'relative',

--- a/src/runtime/components/ScriptYouTubePlayer.vue
+++ b/src/runtime/components/ScriptYouTubePlayer.vue
@@ -115,7 +115,7 @@ const rootAttrs = computed(() => {
       position: 'relative',
       backgroundColor: 'black',
       maxWidth: '100%',
-      width: `${props.width}px`,
+      width: `auto`,
       height: 'auto',
       aspectRatio: `${props.width}/${props.height}`,
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Currently, the media players have a fixed width, which makes them non-responsive on mobile devices. This breaks the view completely, as they overflow way off screen. By making the width automatic, it can be more responsive to small screen sizes and keep the structure of the page.