### PR TITLE
feat(useScriptNpm): support multiple providers with validation

### DIFF
--- a/src/runtime/registry/npm.ts
+++ b/src/runtime/registry/npm.ts
@@ -1,23 +1,41 @@
 import { withBase } from 'ufo'
 import { useRegistryScript } from '../utils'
-import { object, optional, string } from '#nuxt-scripts-validator'
+import { object, optional, string, union, literal } from '#nuxt-scripts-validator'
 import type { RegistryScriptInput } from '#nuxt-scripts/types'
+
+const PROVIDERS = ['jsdelivr', 'cdnjs', 'unpkg'] as const
+type Provider = (typeof PROVIDERS)[number]
+const providerValidator = union(PROVIDERS.map(provider => literal(provider)))
 
 export const NpmOptions = object({
   packageName: string(),
   file: optional(string()),
   version: optional(string()),
-  type: optional(string()),
+  provider: optional(providerValidator),
 })
 
 export type NpmInput = RegistryScriptInput<typeof NpmOptions, true, true, false>
 
 export function useScriptNpm<T extends Record<string | symbol, any>>(_options: NpmInput) {
-  // TODO support multiple providers? (e.g. jsdelivr, cdnjs, etc.) Only unpkg for now
-  return useRegistryScript<T, typeof NpmOptions>(`${_options.packageName}-npm`, options => ({
-    scriptInput: {
-      src: withBase(options.file || '', `https://unpkg.com/${options?.packageName}@${options.version || 'latest'}`),
-    },
-    schema: import.meta.dev ? NpmOptions : undefined,
-  }), _options)
+  return useRegistryScript<T, typeof NpmOptions>(`${_options.packageName}-npm`, (options) => {
+    const baseUrl = getProviderBaseUrl(options.provider, options.packageName, options.version)
+    return {
+      scriptInput: {
+        src: withBase(options.file || '', baseUrl),
+      },
+      schema: import.meta.dev ? NpmOptions : undefined,
+    }
+  }, _options)
+}
+
+function getProviderBaseUrl(provider: Provider = 'unpkg', packageName: string, version: string = 'latest'): string {
+  switch (provider) {
+    case 'jsdelivr':
+      return `https://cdn.jsdelivr.net/npm/${packageName}@${version}/`
+    case 'cdnjs':
+      return `https://cdnjs.cloudflare.com/ajax/libs/${packageName}/${version}/`
+    case 'unpkg':
+    default:
+      return `https://unpkg.com/${packageName}@${version}/`
+  }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves the [TODO](https://github.com/nuxt/scripts/blob/b1e4297d9532b9e5d7b5262353976f4cfdb75419/src/runtime/registry/npm.ts#L16)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Implement the TODO for multiple providers, as I also believe it is necessary.
cmiiw: it seems the optional schema `type` is not being used. So, I would suggest using a `provider` for clearer meaning.
The default provider is unpkg.