### PR TITLE
docs: Improve incorrect example of using useScriptTriggerElement

### DIFF
--- a/docs/content/docs/1.guides/1.script-triggers.md
+++ b/docs/content/docs/1.guides/1.script-triggers.md
@@ -70,7 +70,7 @@ const { trigger } = useScript({
 }, {
   trigger: useScriptTriggerElement({
     trigger: 'hover',
-    somethingEl,
+    el: somethingEl,
   })
 })
 ```


### PR DESCRIPTION
Improve incorrect example of `useScriptTriggerElement` so it includes the specifically named property `el` as such

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR corrects a mistake in the documentation that incorrectly shows the possibility of providing the function `useScriptTriggerElement` with a property called `somethingEl`, while that should be called `el`.
