### PR TITLE
fix: expect type error for optional type deps

### DIFF
--- a/src/runtime/components/ScriptGoogleMaps.vue
+++ b/src/runtime/components/ScriptGoogleMaps.vue
@@ -1,4 +1,7 @@
 <script lang="ts" setup>
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
 /// <reference types="google.maps" />
 import { computed, onBeforeUnmount, onMounted, ref, watch, toRaw } from 'vue'
 import type { HTMLAttributes, ImgHTMLAttributes, Ref, ReservedProps } from 'vue'

--- a/src/runtime/components/ScriptVimeoPlayer.vue
+++ b/src/runtime/components/ScriptVimeoPlayer.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
 /// <reference types="vimeo__player" />
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { HTMLAttributes, ImgHTMLAttributes } from 'vue'

--- a/src/runtime/components/ScriptYouTubePlayer.vue
+++ b/src/runtime/components/ScriptYouTubePlayer.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
 /// <reference types="youtube" />
 import { computed, onMounted, ref, watch } from 'vue'
 import type { HTMLAttributes, ImgHTMLAttributes, Ref } from 'vue'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Since the type dependencies were dropped in commit f54552654d047bf33eeef2a158819b78cdd60518, typechecking in projects that rely on Nuxt scripts is failing.

To get things moving again, I’ve added @ts-nocheck to ignore the type errors for now. I know this isn’t a great solution and can hide real issues, but it’s the best workaround I could come up with at the moment.