### PR TITLE
docs(GoogleMaps): fix typo in package name

### DIFF
--- a/docs/content/scripts/content/google-maps.md
+++ b/docs/content/scripts/content/google-maps.md
@@ -19,10 +19,10 @@ Nuxt Scripts provides a `useScriptGoogleMaps` composable and a headless `ScriptG
 ## Types
 
 To use Google Maps with full TypeScript support, you will need
-to install the `@types/google.map` dependency.
+to install the `@types/google.maps` dependency.
 
 ```bash
-pnpm add -D @types/google.map
+pnpm add -D @types/google.maps
 ```
 
 ## ScriptGoogleMaps


### PR DESCRIPTION
### ❓ Type of change

Fixes a typo in the Google Maps section of docs. Package name was missing an s.

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

