### PR TITLE
fix(googleTagManager): add missing dataLayer type

### DIFF
--- a/src/runtime/registry/google-tag-manager.ts
+++ b/src/runtime/registry/google-tag-manager.ts
@@ -28,6 +28,7 @@ type GoogleTagManagerInstance = GoogleTagManagerDataLayerStatus & {
 }
 interface GoogleTagManagerApi {
   google_tag_manager: GoogleTagManagerInstance
+  dataLayer: DataLayer
 }
 
 declare global {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds bacck the `dataLayer` property for gtm 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
