### PR TITLE
docs: clarify async behavior and default script attributes

### DIFF
--- a/docs/content/docs/1.guides/0.key-concepts.md
+++ b/docs/content/docs/1.guides/0.key-concepts.md
@@ -39,12 +39,14 @@ to the hydration process. Instead, scripts are loaded by default when Nuxt is fu
 
 You can change this behavior by modifying the [defaultScriptOptions](/docs/api/nuxt-config#defaultscriptoptions).
 
-Nuxt Scripts will also insert several extra tags to the script element to help with performance and privacy.
+Nuxt Scripts will also insert several extra tags to the `<script>` element to optimize performance and privacy.
 - `async` - Scripts are loaded asynchronously to prevent blocking the rendering of the page.
 - `defer` - Scripts are deferred to ensure they are executed in the order they are loaded.
 - `crossorigin="anonymous"` - Scripts are loaded with the `anonymous` attribute to prevent them from accessing cookies.
 - `referrerpolicy="no-referrer"` - Scripts are loaded with the `no-referrer` policy to prevent them from sending the referrer header.
+- `fetchpriority="low"` - Scripts are loaded with lower priority to improve page performance.
 
+> **Note:** `async` is not applied by default because `defer` is used. If you need `async`, you can explicitly disable `defer`.  
 
 ## Understanding proxied functions
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #304  : Some users expected `async` to be applied by default, leading to confusion. This update makes the behavior explicit.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Updated documentation to clarify that `async` is not applied by default   because `defer` is used.  
- Added a note explaining how to explicitly enable `async` by disabling `defer`.  
- Improved readability of default script attributes section.

