### PR TITLE
feat(gtm): add onBeforeGtmStart

### DIFF
--- a/docs/content/scripts/tracking/google-tag-manager.md
+++ b/docs/content/scripts/tracking/google-tag-manager.md
@@ -128,10 +128,16 @@ export const GoogleTagManagerOptions = object({
   id: string(),
   /**
    * The name of the dataLayer you want to use
-   * @default 'defaultGtm'
+   * @default 'dataLayer'
    */
   dataLayerName: optional(string())
 })
+```
+
+### Options types
+
+```ts
+type GoogleTagManagerInput = typeof GoogleTagManagerOptions & { onBeforeGtmStart?: ((gtag: Gtag) => void) => void }
 ```
 
 ## Example
@@ -163,3 +169,9 @@ function sendConversion() {
 
 
 ::
+
+## Configuring GTM before it starts
+
+`useScriptGoogleTagManager` initialize Google Tag Manager by itself. This means it pushes the `js`, `config` and the `gtm.start` events for you.
+
+If you need to configure GTM before it starts. For example, (setting the consent mode)[https://developers.google.com/tag-platform/security/guides/consent?hl=fr&consentmode=basic]. You can use the `onBeforeGtmStart` hook which is run right before we push the `gtm.start` event into the dataLayer.

--- a/playground/pages/third-parties/google-tag-manager.vue
+++ b/playground/pages/third-parties/google-tag-manager.vue
@@ -7,7 +7,16 @@ useHead({
 
 // composables return the underlying api as a proxy object and the script state
 const { dataLayer, then, status } = useScriptGoogleTagManager({
-  id: 'GTM-MNJD4B',
+  id: 'GTM-P5KM6KK6',
+  onBeforeGtmStart(gtag) {
+    gtag('consent', 'default', {
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      ad_storage: 'denied',
+      analytics_storage: 'denied',
+      wait_for_update: 500,
+    })
+  },
 }) // id is set via runtime config
 dataLayer.push({
   event: 'page_view',

--- a/playground/pages/third-parties/google-tag-manager.vue
+++ b/playground/pages/third-parties/google-tag-manager.vue
@@ -7,7 +7,7 @@ useHead({
 
 // composables return the underlying api as a proxy object and the script state
 const { dataLayer, then, status } = useScriptGoogleTagManager({
-  id: 'GTM-P5KM6KK6',
+  id: 'GTM-MNJD4B',
   onBeforeGtmStart(gtag) {
     gtag('consent', 'default', {
       ad_user_data: 'denied',

--- a/src/runtime/registry/google-analytics.ts
+++ b/src/runtime/registry/google-analytics.ts
@@ -10,7 +10,7 @@ export interface GTag {
   (fn: 'config' | 'get', opt: string): void
   (fn: 'event', opt: string, opt2?: Record<string, any>): void
   (fn: 'set', opt: Record<string, string>): void
-  (fn: 'consent', opt: ConsentOptions, opt2: Record<string, string>): void
+  (fn: 'consent', opt: ConsentOptions, opt2: Record<string, string | number>): void
 }
 type DataLayer = Array<Parameters<GTag> | Record<string, unknown>>
 

--- a/src/runtime/registry/google-tag-manager.ts
+++ b/src/runtime/registry/google-tag-manager.ts
@@ -41,7 +41,7 @@ export const GoogleTagManagerOptions = object({
 
 export type GoogleTagManagerInput = RegistryScriptInput<typeof GoogleTagManagerOptions>
 
-export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(_options?: GoogleTagManagerInput) {
+export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(_options?: GoogleTagManagerInput & { onBeforeGtmStart?: (dataLayer: DataLayer) => void }) {
   return useRegistryScript<T, typeof GoogleTagManagerOptions>(_options?.key || 'googleTagManager', options => ({
     scriptInput: {
       src: withQuery('https://www.googletagmanager.com/gtm.js', { id: options?.id, l: options?.l }),
@@ -53,13 +53,14 @@ export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(_option
       },
       stub: import.meta.client ? undefined : ({ fn }) => { return fn === 'dataLayer' ? [] : void 0 },
       performanceMarkFeature: 'nuxt-third-parties-gtm',
-      ...({ tagPriority: 1 }),
+      tagPriority: 1,
     },
     clientInit: import.meta.server
       ? undefined
       : () => {
           const dataLayerName = options?.l ?? 'dataLayer';
           (window as any)[dataLayerName] = (window as any)[(options?.l ?? 'dataLayer')] || []
+          _options?.onBeforeGtmStart?.((window as any)[dataLayerName])
           ;(window as any)[dataLayerName].push({ 'gtm.start': new Date().getTime(), 'event': 'gtm.js' })
         },
   }), _options)

--- a/src/runtime/registry/google-tag-manager.ts
+++ b/src/runtime/registry/google-tag-manager.ts
@@ -41,7 +41,7 @@ export const GoogleTagManagerOptions = object({
 
 export type GoogleTagManagerInput = RegistryScriptInput<typeof GoogleTagManagerOptions>
 
-export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(_options?: GoogleTagManagerInput & { onBeforeGtmStart?: (dataLayer: DataLayer) => void }) {
+export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(_options?: GoogleTagManagerInput & { onBeforeGtmStart?: (gtag: GTag) => void }) {
   return useRegistryScript<T, typeof GoogleTagManagerOptions>(_options?.key || 'googleTagManager', options => ({
     scriptInput: {
       src: withQuery('https://www.googletagmanager.com/gtm.js', { id: options?.id, l: options?.l }),
@@ -60,7 +60,11 @@ export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(_option
       : () => {
           const dataLayerName = options?.l ?? 'dataLayer';
           (window as any)[dataLayerName] = (window as any)[(options?.l ?? 'dataLayer')] || []
-          _options?.onBeforeGtmStart?.((window as any)[dataLayerName])
+          function gtag() {
+            // eslint-disable-next-line prefer-rest-params
+            (window as any)[dataLayerName].push(arguments)
+          }
+          _options?.onBeforeGtmStart?.(gtag)
           ;(window as any)[dataLayerName].push({ 'gtm.start': new Date().getTime(), 'event': 'gtm.js' })
         },
   }), _options)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolve #243
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR improves GTM by adding a new callback to allow users to push anything into the datalayer before we push gtm.start . This way, users will be able to correctly set the consent mode
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
