### PR TITLE
feat: added ability to change tagmanager and analytics script src

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -247,7 +247,7 @@ export const registry: (resolve?: (s: string) => string) => RegistryScripts = (r
       },
       logo: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 256 256"><path fill="#8AB4F8" d="m150.262 245.516l-44.437-43.331l95.433-97.454l46.007 45.091z"/><path fill="#4285F4" d="M150.45 53.938L106.176 8.731L9.36 104.629c-12.48 12.48-12.48 32.713 0 45.207l95.36 95.986l45.09-42.182l-72.654-76.407z"/><path fill="#8AB4F8" d="m246.625 105.37l-96-96c-12.494-12.494-32.756-12.494-45.25 0c-12.495 12.495-12.495 32.757 0 45.252l96 96c12.494 12.494 32.756 12.494 45.25 0c12.495-12.495 12.495-32.757 0-45.251"/><circle cx="127.265" cy="224.731" r="31.273" fill="#246FDB"/></svg>`,
       scriptBundling(options) {
-        return withQuery('https://www.googletagmanager.com/gtag/js', { id: options?.id, l: options?.l })
+        return withQuery(options.src || 'https://www.googletagmanager.com/gtag/js', { id: options?.id, l: options?.l })
       },
     },
     {
@@ -259,7 +259,7 @@ export const registry: (resolve?: (s: string) => string) => RegistryScripts = (r
       },
       logo: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" width="192px" height="192px" viewBox="0 0 192 192" enable-background="new 0 0 192 192" xml:space="preserve"><rect x="0" y="0" fill="none" width="192" height="192"/><g><g><path fill="#F9AB00" d="M130,29v132c0,14.77,10.19,23,21,23c10,0,21-7,21-23V30c0-13.54-10-22-21-22S130,17.33,130,29z"/></g><g><path fill="#E37400" d="M75,96v65c0,14.77,10.19,23,21,23c10,0,21-7,21-23V97c0-13.54-10-22-21-22S75,84.33,75,96z"/></g><g><circle fill="#E37400" cx="41" cy="163" r="21"/></g></g></svg>`,
       scriptBundling(options) {
-        return withQuery('https://www.googletagmanager.com/gtag/js', { id: options?.id, l: options?.l })
+        return withQuery(options.src || 'https://www.googletagmanager.com/gtag/js', { id: options?.id, l: options?.l })
       },
     },
     {

--- a/src/runtime/registry/google-analytics.ts
+++ b/src/runtime/registry/google-analytics.ts
@@ -29,7 +29,7 @@ export interface GoogleAnalyticsApi {
 export function useScriptGoogleAnalytics<T extends GoogleAnalyticsApi>(_options?: GoogleAnalyticsInput) {
   return useRegistryScript<T, typeof GoogleAnalyticsOptions>(_options?.key || 'googleAnalytics', options => ({
     scriptInput: {
-      src: withQuery('https://www.googletagmanager.com/gtag/js', { id: options?.id, l: options?.l }),
+      src: withQuery(options.src || 'https://www.googletagmanager.com/gtag/js', { id: options?.id, l: options?.l }),
     },
     schema: import.meta.dev ? GoogleAnalyticsOptions : undefined,
     scriptOptions: {

--- a/src/runtime/registry/google-tag-manager.ts
+++ b/src/runtime/registry/google-tag-manager.ts
@@ -44,7 +44,7 @@ export type GoogleTagManagerInput = RegistryScriptInput<typeof GoogleTagManagerO
 export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(_options?: GoogleTagManagerInput & { onBeforeGtmStart?: (gtag: GTag) => void }) {
   return useRegistryScript<T, typeof GoogleTagManagerOptions>(_options?.key || 'googleTagManager', options => ({
     scriptInput: {
-      src: withQuery('https://www.googletagmanager.com/gtm.js', { id: options?.id, l: options?.l }),
+      src: withQuery(options.src || 'https://www.googletagmanager.com/gtm.js', { id: options?.id, l: options?.l }),
     },
     schema: import.meta.dev ? GoogleTagManagerOptions : undefined,
     scriptOptions: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->
## feat: added ability to change tagmanager and analytics script src

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves https://github.com/nuxt/scripts/issues/404

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Currently, there is no way to change the src of the tag manager script without losing the ability of the id being appended automatically. Changing the src is necessary for server side tagging to work.

This PR adds a new option to the tag manager (and analytics) options to change the src directly. This keeps the current functionality intact while allowing a custom src.

```
googleTagManager: {
	id: 'GTM-123456',
	src: 'https://gtm.example.com/gtm.js'
},
```