### PR TITLE
fix: resolve @unhead/vue from module and catch if fails

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -117,7 +117,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
     // couldn't be found for some reason, assume compatibility
     const { version: unheadVersion } = await readPackageJSON('@unhead/vue', {
-      from: import.meta.url,
+      from: nuxt.options.modulesDir,
     }).catch(() => ({ version: null }))
     if (unheadVersion?.startsWith('1')) {
       logger.error(`Nuxt Scripts requires Unhead >= 2, you are using v${unheadVersion}. Please run \`nuxi upgrade --clean\` to upgrade...`)

--- a/src/module.ts
+++ b/src/module.ts
@@ -116,7 +116,9 @@ export default defineNuxtModule<ModuleOptions>({
       return
     }
     // couldn't be found for some reason, assume compatibility
-    const { version: unheadVersion } = await readPackageJSON('@unhead/vue')
+    const { version: unheadVersion } = await readPackageJSON('@unhead/vue', {
+      from: import.meta.url,
+    }).catch(() => ({ version: null }))
     if (unheadVersion?.startsWith('1')) {
       logger.error(`Nuxt Scripts requires Unhead >= 2, you are using v${unheadVersion}. Please run \`nuxi upgrade --clean\` to upgrade...`)
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We need to resolve @unhead/vue from the module location. 
A .catch has been added in case `readPackageJSON` wasn't able to find `@unhead/vue`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
