### PR TITLE
chore: add ohash v1 to docs deploy

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,7 @@
     "@vueuse/nuxt": "^12.8.2",
     "nuxt-content-twoslash": "^0.1.2",
     "nuxt-llms": "^0.1.0",
+    "ohash": "^1.1.6",
     "shiki": "^3.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       nuxt-llms:
         specifier: ^0.1.0
         version: 0.1.0(magicast@0.3.5)
+      ohash:
+        specifier: ^1.1.6
+        version: 1.1.6
       shiki:
         specifier: ^3.1.0
         version: 3.1.0


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

aims to resolve docs deploy + unblock CI by adding ohash v1 manually - but only in docs (which ui-pro still depends on) - a similar strategy [worked for nuxt/fonts](https://github.com/nuxt/fonts/pull/558)

docs are still failing due to unenv hoisting