### PR TITLE
fix(googleMaps): configurable google map options

### DIFF
--- a/docs/content/scripts/tracking/google-tag-manager.md
+++ b/docs/content/scripts/tracking/google-tag-manager.md
@@ -174,4 +174,4 @@ function sendConversion() {
 
 `useScriptGoogleTagManager` initialize Google Tag Manager by itself. This means it pushes the `js`, `config` and the `gtm.start` events for you.
 
-If you need to configure GTM before it starts. For example, (setting the consent mode)[https://developers.google.com/tag-platform/security/guides/consent?consentmode=basic]. You can use the `onBeforeGtmStart` hook which is run right before we push the `gtm.start` event into the dataLayer.
+If you need to configure GTM before it starts. For example, [setting the consent mode](https://developers.google.com/tag-platform/security/guides/consent?consentmode=basic). You can use the `onBeforeGtmStart` hook which is run right before we push the `gtm.start` event into the dataLayer.

--- a/docs/content/scripts/tracking/google-tag-manager.md
+++ b/docs/content/scripts/tracking/google-tag-manager.md
@@ -174,4 +174,4 @@ function sendConversion() {
 
 `useScriptGoogleTagManager` initialize Google Tag Manager by itself. This means it pushes the `js`, `config` and the `gtm.start` events for you.
 
-If you need to configure GTM before it starts. For example, (setting the consent mode)[https://developers.google.com/tag-platform/security/guides/consent?hl=fr&consentmode=basic]. You can use the `onBeforeGtmStart` hook which is run right before we push the `gtm.start` event into the dataLayer.
+If you need to configure GTM before it starts. For example, (setting the consent mode)[https://developers.google.com/tag-platform/security/guides/consent?consentmode=basic]. You can use the `onBeforeGtmStart` hook which is run right before we push the `gtm.start` event into the dataLayer.

--- a/src/runtime/components/ScriptGoogleMaps.vue
+++ b/src/runtime/components/ScriptGoogleMaps.vue
@@ -121,6 +121,7 @@ const { load, status, onLoaded } = useScriptGoogleMaps({
   scriptOptions: {
     trigger,
   },
+  ...props.mapOptions
 })
 
 const options = computed(() => {

--- a/src/runtime/registry/google-maps.ts
+++ b/src/runtime/registry/google-maps.ts
@@ -20,7 +20,7 @@ export const GoogleMapsOptions = object({
   libraries: optional(array(string())),
   language: optional(string()),
   region: optional(string()),
-  v: optional(union([literal('weekly'), literal('beta'), literal('alpha')])),
+  v: optional(union([literal('weekly'), literal('quarterly'), literal('beta'), literal('alpha'), string()])),
 })
 
 export type GoogleMapsInput = RegistryScriptInput<typeof GoogleMapsOptions>
@@ -46,6 +46,7 @@ export function useScriptGoogleMaps<T extends GoogleMapsApi>(_options?: GoogleMa
     const libraries = options?.libraries || ['places']
     const language = options?.language ? { language: options.language } : undefined
     const region = options?.region ? { region: options.region } : undefined
+    const version = options?.v ? { v: options.v } : undefined
     return {
       scriptInput: {
         src: withQuery(`https://maps.googleapis.com/maps/api/js`, {
@@ -55,6 +56,7 @@ export function useScriptGoogleMaps<T extends GoogleMapsApi>(_options?: GoogleMa
           callback: 'google.maps.__ib__',
           ...language,
           ...region,
+          ...version
         }),
       },
       clientInit: import.meta.server


### PR DESCRIPTION
### 🔗 Linked issue

Should resolve #336 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The useScriptGoogleMaps composable has had parameters for region and language added on #286 but the component was not passing the required prop to the composable so we could not set the region, language or version parameters on the component.

We can now set these parameters on the component as per the following example:

```
<ScriptGoogleMaps ref="maps" :mapOptions="{ region: 'PT', language: 'PT', v: '3.59' }"/>
```

Also, the version parameter previously only allowed values weekly, alpha and beta. This adds "quarterly" or specific version string.  (See https://developers.google.com/maps/documentation/javascript/versions)

Also fixed a link and markdown syntax issue on the documentation page about the Google Tag Manager

Cheers 👍 
