### PR TITLE
fix: typecheck error

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,10 +1,8 @@
 import type {
-  ActiveHeadEntry,
-  AsAsyncFunctionValues,
   DataKeys,
   SchemaAugmentations,
-  ScriptBase,
-} from '@unhead/schema'
+  ScriptWithoutEvents,
+} from 'unhead/types'
 import type { UseScriptInput, VueScriptInstance, UseScriptOptions } from '@unhead/vue'
 import type { ComputedRef, Ref } from 'vue'
 import type { InferInput, ObjectSchema } from 'valibot'
@@ -35,17 +33,7 @@ import { object } from '#nuxt-scripts-validator'
 
 export type WarmupStrategy = false | 'preload' | 'preconnect' | 'dns-prefetch'
 
-export type UseScriptContext<T extends Record<symbol | string, any>> =
-  (Promise<T> & VueScriptInstance<T>)
-  & AsAsyncFunctionValues<T>
-  & {
-  /**
-   * @deprecated Use top-level functions instead.
-   */
-    $script: Promise<T> & VueScriptInstance<T>
-    warmup: (rel: WarmupStrategy) => void
-    _warmupEl?: void | ActiveHeadEntry<any>
-  }
+export type UseScriptContext<T extends Record<symbol | string, any>> = VueScriptInstance<T>
 
 export type NuxtUseScriptOptions<T extends Record<symbol | string, any> = {}> = Omit<UseScriptOptions<T>, 'trigger'> & {
   /**
@@ -176,7 +164,7 @@ const _emptyOptions = object({})
 
 export type EmptyOptionsSchema = typeof _emptyOptions
 
-type ScriptInput = ScriptBase & DataKeys & SchemaAugmentations['script']
+type ScriptInput = ScriptWithoutEvents & DataKeys & SchemaAugmentations['script']
 
 export type InferIfSchema<T> = T extends ObjectSchema<any, any> ? InferInput<T> : T
 export type RegistryScriptInput<


### PR DESCRIPTION
### 🔗 Linked issue
Resolves https://github.com/nuxt/scripts/issues/419

### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description
I'm new to OSS contributions, so I appreciate any feedback or corrections. 🙏

#### 🔹 Summary
The `@unhead/schema` package is now deprecated, and it is recommended to import types from `unhead/types` instead.  
This PR updates the type imports accordingly.

https://unhead-unjs-io.nuxt.dev/docs/migration#deprecated-unheadschema

#### 🔹 Changes
1. **Updated UseScriptContext type definition**
   ```ts
   export type UseScriptContext<T extends Record<symbol | string, any>> = ScriptInstance<T>
   ```
   
   - **Reference**: [unhead/src/scripts/types.ts#L13](https://github.com/unjs/unhead/blob/9d837c2217240f4e997cf18a25b79632ef8d6c24/packages/unhead/src/scripts/types.ts#L13)

2. **Converted ScriptBase to ScriptWithoutEvents**
   ```ts
   type ScriptInput = ScriptWithoutEvents & DataKeys & SchemaAugmentations['script']
   ```
   
   - **Reference**: [unhead commit](https://github.com/unjs/unhead/commit/a516899d56b12573e669501bfb9eded360bb6a2d#diff-c59eaa30da74335777c0a85192105f86ec298de5079bcee76c5e39815e5d559cL7)

#### 🔹 Reason
- `@unhead/schema` has been **deprecated** and will be removed in a future version.
- The recommended way to import types is now `unhead/types`.
