### PR TITLE
fix(googleMaps): region, language and version be own props

### DIFF
--- a/src/runtime/components/ScriptGoogleMaps.vue
+++ b/src/runtime/components/ScriptGoogleMaps.vue
@@ -63,6 +63,18 @@ const props = withDefaults(defineProps<{
    */
   mapOptions?: google.maps.MapOptions
   /**
+   * Defines the region of the map.
+   */
+  region?: string
+  /**
+   * Defines the language of the map
+   */
+  language?: string
+  /**
+   * Defines the version of google maps js API
+   */
+  version?: string
+  /**
    * Defines the width of the map.
    */
   width?: number | string
@@ -121,7 +133,9 @@ const { load, status, onLoaded } = useScriptGoogleMaps({
   scriptOptions: {
     trigger,
   },
-  ...props.mapOptions,
+  region: props.region,
+  language: props.language,
+  v: props.version,
 })
 
 const options = computed(() => {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

On my previous PR I had added these params inside mapOptions which turns out is not correct since that maps to [google.maps.mapOptions](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions). (sorry 😩)

They're separate props now.
