### PR TITLE
fix: center marker always shown on maps placeholder image #402

### DIFF
--- a/src/runtime/components/ScriptGoogleMaps.vue
+++ b/src/runtime/components/ScriptGoogleMaps.vue
@@ -418,7 +418,7 @@ const placeholder = computed(() => {
     style: props.mapOptions?.styles ? transformMapStyles(props.mapOptions.styles) : undefined,
     markers: [
       ...(props.markers || []),
-      center,
+      (typeof props.centerMarker === 'undefined' || props.centerMarker) && center,
     ]
       .filter(Boolean)
       .map((m) => {


### PR DESCRIPTION
Center marker always shown on maps placeholder image, no matter the value of `center-marker` prop

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #402 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Center marker was always shown on maps placeholder image, no matter the value of `center-marker` prop. 
