### PR TITLE
fix: properly handle centerMarker removal logic

### DIFF
--- a/src/runtime/components/ScriptGoogleMaps.vue
+++ b/src/runtime/components/ScriptGoogleMaps.vue
@@ -105,6 +105,7 @@ const props = withDefaults(defineProps<{
   trigger: ['mouseenter', 'mouseover', 'mousedown'],
   width: 640,
   height: 400,
+  centerMarker: true
 })
 
 const emits = defineEmits<{
@@ -306,7 +307,7 @@ onMounted(() => {
     // do a diff of next and prev
     const centerHash = hash({ position: options.value.center })
     for (const key of toRemove) {
-      if (key === centerHash) {
+      if (props.centerMarker && key === centerHash) {
         continue
       }
       const marker = await mapMarkers.value.get(key)
@@ -335,7 +336,7 @@ onMounted(() => {
         center = await resolveQueryToLatLang(center as string)
       }
       map.value!.setCenter(center as google.maps.LatLng)
-      if (typeof props.centerMarker === 'undefined' || props.centerMarker) {
+      if (props.centerMarker) {
         if (options.value.mapId) {
           // not allowed to use advanced markers with styles
           return
@@ -418,7 +419,7 @@ const placeholder = computed(() => {
     style: props.mapOptions?.styles ? transformMapStyles(props.mapOptions.styles) : undefined,
     markers: [
       ...(props.markers || []),
-      (typeof props.centerMarker === 'undefined' || props.centerMarker) && center,
+      props.centerMarker && center,
     ]
       .filter(Boolean)
       .map((m) => {


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
This is a follow-up to my previous fix related to the centerMarkers #402 #454 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

This PR addresses another issue with the `centerMarker` prop in the Google Maps component:

**Fixed center marker removal bug**: The marker removal logic was incorrectly protecting center markers from deletion regardless of the `centerMarker` prop state, causing center markers to persist even when disabled

**Added explicit default value**: Set `centerMarker: true` in props defaults to make the component's behavior predictable and consistent with its implicit logic