### PR TITLE
fix(meta-pixel): refine fbq type definitions

### DIFF
--- a/docs/content/scripts/tracking/meta-pixel.md
+++ b/docs/content/scripts/tracking/meta-pixel.md
@@ -107,18 +107,23 @@ export interface MetaPixelApi {
   }
   _fbq: MetaPixelApi['fbq']
 }
-type FbqFns = ((event: 'track', eventName: StandardEvents, data?: EventObjectProperties) => void)
-  & ((event: 'trackCustom', eventName: string, data?: EventObjectProperties) => void)
-  & ((event: 'init', id: number, data?: Record<string, any>) => void)
-  & ((event: 'init', id: string) => void)
-  & ((event: string, ...params: any[]) => void)
+type FbqArgs =
+  | ['track', StandardEvents, EventObjectProperties?]
+  | ['trackCustom', string, EventObjectProperties?]
+  | ['trackSingle', string, StandardEvents, EventObjectProperties?]
+  | ['trackSingleCustom', string, string, EventObjectProperties?]
+  | ['init', string]
+  | ['init', number, Record<string, any>?]
+  | ['consent', ConsentAction]
+  | [string, ...any[]]
+type FbqFns = (...args: FbqArgs) => void
 type StandardEvents = 'AddPaymentInfo' | 'AddToCart' | 'AddToWishlist' | 'CompleteRegistration' | 'Contact' | 'CustomizeProduct' | 'Donate' | 'FindLocation' | 'InitiateCheckout' | 'Lead' | 'Purchase' | 'Schedule' | 'Search' | 'StartTrial' | 'SubmitApplication' | 'Subscribe' | 'ViewContent'
 interface EventObjectProperties {
   content_category?: string
   content_ids?: string[]
   content_name?: string
   content_type?: string
-  contents: { id: string, quantity: number }[]
+  contents?: { id: string, quantity: number }[]
   currency?: string
   delivery_category?: 'in_store' | 'curbside' | 'home_delivery'
   num_items?: number
@@ -128,6 +133,7 @@ interface EventObjectProperties {
   value?: number
   [key: string]: any
 }
+type ConsentAction = 'grant' | 'revoke'
 ```
 
 ### Config Schema

--- a/src/runtime/registry/meta-pixel.ts
+++ b/src/runtime/registry/meta-pixel.ts
@@ -8,7 +8,7 @@ interface EventObjectProperties {
   content_ids?: string[]
   content_name?: string
   content_type?: string
-  contents: { id: string, quantity: number }[]
+  contents?: { id: string, quantity: number }[]
   currency?: string
   delivery_category?: 'in_store' | 'curbside' | 'home_delivery'
   num_items?: number
@@ -18,8 +18,19 @@ interface EventObjectProperties {
   value?: number
   [key: string]: any
 }
+type ConsentAction = 'grant' | 'revoke'
 
-type FbqFns = ((event: 'track', eventName: StandardEvents, data?: EventObjectProperties) => void) & ((event: 'trackCustom', eventName: string, data?: EventObjectProperties) => void) & ((event: 'init', id: number, data?: Record<string, any>) => void) & ((event: 'init', id: string) => void) & ((event: string, ...params: any[]) => void)
+type FbqArgs =
+  | ['track', StandardEvents, EventObjectProperties?]
+  | ['trackCustom', string, EventObjectProperties?]
+  | ['trackSingle', string, StandardEvents, EventObjectProperties?]
+  | ['trackSingleCustom', string, string, EventObjectProperties?]
+  | ['init', string]
+  | ['init', number, Record<string, any>?]
+  | ['consent', ConsentAction]
+  // fallback: allow any fbq call signature not covered above
+  | [string, ...any[]]
+type FbqFns = (...args: FbqArgs) => void
 
 export interface MetaPixelApi {
   fbq: FbqFns & {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR refactors the Meta Pixel (fbq) integration to improve type safety and developer experience.

- Adds explicit types for each valid fbq call pattern
- Adds support for additional Meta Pixel call patterns
    - trackSingle
    - trackSingleCustom
    - consent
- Adds a fallback [string, ...any[]] signature at the end to preserve compatibility with undocumented or custom usages
- Makes contents in EventObjectProperties optional to prevent type errors in common usage
- Updates documentation to reflect the new types

### References

https://developers.facebook.com/docs/meta-pixel/advanced
https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/
