### PR TITLE
chore: remove `bridge: false` from module compatibility

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -86,7 +86,6 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'scripts',
     compatibility: {
       nuxt: '>=3.16',
-      bridge: false,
     },
   },
   defaults: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this is to fix types for nuxt v4

and also, the constraint of `>=3.16` would also prohibit the usage of bridge, so this is likely not needed anyway.