### PR TITLE
feat: add `forceDownload` option to bypass script cache

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -227,6 +227,7 @@ export {}`
       addBuildPlugin(NuxtScriptBundleTransformer({
         scripts: registryScriptsWithImport,
         defaultBundle: config.defaultScriptOptions?.bundle,
+        defaultForceDownload: config.defaultScriptOptions?.forceDownload,
         moduleDetected(module) {
           if (nuxt.options.dev && module !== '@nuxt/scripts' && !moduleInstallPromises.has(module) && !hasNuxtModule(module))
             moduleInstallPromises.set(module, () => installNuxtModule(module))

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -51,6 +51,15 @@ export type NuxtUseScriptOptions<T extends Record<symbol | string, any> = {}> = 
    */
   bundle?: boolean
   /**
+   * Force download of the script even if it exists in cache. Useful for development workflows
+   * where you want to ensure the latest version is always downloaded.
+   * - `true` - Force download, bypass cache.
+   * - `false` - Use cached version if available. (default)
+   *
+   * Note: This may significantly increase build time as scripts will be re-downloaded on every build.
+   */
+  forceDownload?: boolean
+  /**
    * Skip any schema validation for the script input. This is useful for loading the script stubs for development without
    * loading the actual script and not getting warnings.
    */
@@ -173,16 +182,16 @@ export type RegistryScriptInput<
   Usable extends boolean = false,
   CanBypassOptions extends boolean = true,
 >
-    = (InferIfSchema<T>
-      & {
+  = (InferIfSchema<T>
+    & {
       /**
        * A unique key to use for the script, this can be used to load multiple of the same script with different options.
        */
-        key?: string
-        scriptInput?: ScriptInput
-        scriptOptions?: Omit<NuxtUseScriptOptions, Bundelable extends true ? '' : 'bundle' | Usable extends true ? '' : 'use'>
-      })
-      | Partial<InferIfSchema<T>> & (
+      key?: string
+      scriptInput?: ScriptInput
+      scriptOptions?: Omit<NuxtUseScriptOptions, Bundelable extends true ? '' : 'bundle' | Usable extends true ? '' : 'use'>
+    })
+    | Partial<InferIfSchema<T>> & (
       CanBypassOptions extends true ? {
       /**
        * A unique key to use for the script, this can be used to load multiple of the same script with different options.


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#485
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add forceDownload option for development workflows where the latest version of scripts should always be downloaded, bypassing cache.

- Add forceDownload option to NuxtUseScriptOptions type with comprehensive documentation
- Update AssetBundlerTransformerOptions to include defaultForceDownload configuration
- Modify downloadScript function to skip cache when forceDownload is true
- Add logic to extract forceDownload option from script configuration
- Pass defaultForceDownload from module configuration to transformer
- Includes performance warnings about build time impact


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
