### PR TITLE
fix: add TypeScript path mapping for Nuxt 4 compatibility

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -108,6 +108,17 @@ export default defineNuxtModule<ModuleOptions>({
     const { version, name } = await readPackageJSON(await resolvePath('../package.json'))
     nuxt.options.alias['#nuxt-scripts-validator'] = await resolvePath(`./runtime/validation/${(nuxt.options.dev || nuxt.options._prepare) ? 'valibot' : 'mock'}`)
     nuxt.options.alias['#nuxt-scripts'] = await resolvePath('./runtime')
+
+    // Ensure TypeScript path mapping for Nuxt 4 compatibility
+    nuxt.hooks.hook('prepare:types', async (options) => {
+      // Ensure paths are configured in TypeScript
+      if (options.tsConfig?.compilerOptions?.paths) {
+        options.tsConfig.compilerOptions.paths['#nuxt-scripts/*'] = [
+          await resolvePath('./runtime/*'),
+        ]
+      }
+    })
+
     logger.level = (config.debug || nuxt.options.debug) ? 4 : 3
     if (!config.enabled) {
       // TODO fallback to useHead?


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#483
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add TypeScript path mapping configuration to ensure #nuxt-scripts/* imports work correctly in Nuxt 4.

- Add prepare:types hook to configure TypeScript paths
- Ensure #nuxt-scripts/* resolves to runtime/* in TypeScript configuration
- Maintains backward compatibility with Nuxt 3.16+


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
