### PR TITLE
fix: add null safety to DevTools syncScripts function

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -10,6 +10,10 @@ const scripts = ref({})
 const scriptSizes = reactive<Record<string, string>>({})
 
 function syncScripts(_scripts: any[]) {
+  if (!_scripts || typeof _scripts !== 'object') {
+    scripts.value = {}
+    return
+  }
   // augment the scripts with registry
   scripts.value = Object.fromEntries(
     Object.entries({ ..._scripts })
@@ -54,7 +58,7 @@ onDevtoolsClientConnected(async (client) => {
     syncScripts(ctx.scripts)
   })
   version.value = client.host.nuxt.$config.public['nuxt-scripts'].version
-  syncScripts(client.host.nuxt._scripts)
+  syncScripts(client.host.nuxt._scripts || {})
 })
 const tab = ref('scripts')
 


### PR DESCRIPTION
### 🔗 Linked issue

#481

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add null/undefined checks to prevent 500 errors in Nuxt 4 when DevTools tries to access _scripts that may not exist.

- Add null safety check in syncScripts function to handle undefined _scripts
- Add fallback empty object when calling syncScripts with potentially undefined _scripts
- Fixes DevTools 500 error when _scripts is undefined in Nuxt 4 setups


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
