### PR TITLE
feat(stripe)!: Stripe basil

### DIFF
--- a/src/runtime/registry/stripe.ts
+++ b/src/runtime/registry/stripe.ts
@@ -18,7 +18,7 @@ export function useScriptStripe<T extends StripeApi>(_options?: StripeInput) {
   return useRegistryScript<T, typeof StripeOptions>('stripe', options => ({
     scriptInput: {
       src: withQuery(
-        `https://js.stripe.com/v3/`,
+        `https://js.stripe.com/basil/stripe.js`,
         (typeof options?.advancedFraudSignals === 'boolean' && !options?.advancedFraudSignals) ? { advancedFraudSignals: false } : {},
       ),
       // opt-out of privacy defaults

--- a/src/runtime/registry/stripe.ts
+++ b/src/runtime/registry/stripe.ts
@@ -1,5 +1,5 @@
 import { withQuery } from 'ufo'
-import type { Stripe } from '@stripe/stripe-js'
+import type { StripeConstructor } from '@stripe/stripe-js'
 import { useRegistryScript } from '../utils'
 import { boolean, object, optional } from '#nuxt-scripts-validator'
 import type { RegistryScriptInput } from '#nuxt-scripts/types'

--- a/src/runtime/registry/stripe.ts
+++ b/src/runtime/registry/stripe.ts
@@ -11,7 +11,7 @@ export const StripeOptions = object({
 export type StripeInput = RegistryScriptInput<typeof StripeOptions, false>
 
 export interface StripeApi {
-  Stripe: Stripe
+  Stripe: StripeConstructor
 }
 
 export function useScriptStripe<T extends StripeApi>(_options?: StripeInput) {


### PR DESCRIPTION
### 🔗 Linked issue

"Resolves #508 " 

### ❓ Type of change:

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request updates the url and type of the exposed stripe instance by the composable, when i followed the guide to implement stripe with nuxt/scripts i detected typescript errors that shouldnt be there, the reason was that the previous versions of stripe's library used to expose the constructor as Stripe, however in the newer versions the type is called StripeConstructor.

The reason im marking it as a breaking change is the fact that stripes api has changed considerably with the newer version, and updating nuxt/scripts would automatically update the library which can cause implementation problems because of the deprecated functions and such.

If this being a breaking change is a problem i can also implement a different script for the newer version of stripe. and maintain the previous as legacy.
