### PR TITLE
fix: move @nuxt/kit into peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "@types/google.maps": "^3.58.1",
     "@types/vimeo__player": "^2.18.3",
     "@types/youtube": "^0.1.0",
-    "@unhead/vue": "^2.0.3"
+    "@unhead/vue": "^2.0.3",
+    "@nuxt/kit": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@stripe/stripe-js": {
@@ -98,7 +99,6 @@
     }
   },
   "dependencies": {
-    "@nuxt/kit": "^4.1.2",
     "@vueuse/core": "^13.9.0",
     "consola": "^3.4.2",
     "defu": "^6.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       '@nuxt/kit':
-        specifier: ^4.1.2
+        specifier: ^3.0.0 || ^4.0.0
         version: 4.1.2(magicast@0.3.5)
       '@stripe/stripe-js':
         specifier: ^7.0.0


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fix #519 

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

This PR moves @nuxt/kit to peerDependencies so users in Nuxt 3 wouldn't have @nuxt/kit 4 getting used due to the dependency graph of nuxt scripts

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
