### PR TITLE
fix(gtm): expose `gtag` globally

### DIFF
--- a/src/runtime/registry/google-tag-manager.ts
+++ b/src/runtime/registry/google-tag-manager.ts
@@ -167,6 +167,9 @@ export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(
                 (window as any)[dataLayerName].push(arguments)
               }
 
+              // Assign gtag to window for global access
+              (window as any).gtag = gtag
+
               // Allow custom initialization
               options?.onBeforeGtmStart?.(gtag);
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Global gtag function not exposed when using GTM via useScriptGoogleTagManager (https://github.com/nuxt/scripts/issues/523)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Expose globally the gtag function on the Google Tag Manager Script, useful for consent updates.
