### PR TITLE
fix: databuddy type safe script registry

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -7,6 +7,7 @@ import type { InferInput, ObjectSchema, ValiError } from 'valibot'
 import type { Import } from 'unimport'
 import type { SegmentInput } from './registry/segment'
 import type { CloudflareWebAnalyticsInput } from './registry/cloudflare-web-analytics'
+import type { DatabuddyAnalyticsInput } from './registry/databuddy-analytics'
 import type { MetaPixelInput } from './registry/meta-pixel'
 import type { FathomAnalyticsInput } from './registry/fathom-analytics'
 import type { HotjarInput } from './registry/hotjar'
@@ -134,6 +135,7 @@ export interface ScriptRegistry {
   crisp?: CrispInput
   clarity?: ClarityInput
   cloudflareWebAnalytics?: CloudflareWebAnalyticsInput
+  databuddyAnalytics?: DatabuddyAnalyticsInput
   metaPixel?: MetaPixelInput
   fathomAnalytics?: FathomAnalyticsInput
   plausibleAnalytics?: PlausibleAnalyticsInput


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request introduces support for Databuddy Analytics by updating type definitions. The changes ensure that Databuddy Analytics can be properly referenced and configured within the application's script registry.

Analytics integration:

* Added import for `DatabuddyAnalyticsInput` in `src/runtime/types.ts` to enable type checking for Databuddy Analytics configuration.
* Extended the `ScriptRegistry` interface in `src/runtime/types.ts` to include an optional `databuddyAnalytics` property, allowing Databuddy Analytics to be registered alongside other analytics providers.
