### PR TITLE
fix(google-maps): mark peer dependency as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "@unhead/vue": "^2.0.3"
   },
   "peerDependenciesMeta": {
+    "@googlemaps/markerclusterer": {
+      "optional": true
+    },
     "@stripe/stripe-js": {
       "optional": true
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #536

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
This marks the dependency `@googlemaps/markerclusterer` introduced in PR #510 as an optional peer dependency so that it is not installed when installing `@nuxt/scripts` >= v0.12.0
