### PR TITLE
fix(x-pixel): correct variable name from e.exe to s.exe

### DIFF
--- a/src/runtime/registry/x-pixel.ts
+++ b/src/runtime/registry/x-pixel.ts
@@ -58,7 +58,7 @@ export function useScriptXPixel<T extends XPixelApi>(_options?: XPixelInput) {
           // @ts-expect-error untyped
             const s = window.twq = function (...args) {
               // @ts-expect-error untyped
-              if (e.exe) {
+              if (s.exe) {
                 // @ts-expect-error untyped
                 s.exe(s, args)
               }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- None -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes a typo in `src/runtime/registry/x-pixel.ts` where
`if (e.exe)` should be `if (s.exe)`.

This bug was introduced in https://github.com/nuxt/scripts/commit/3c46cffcb8fc13f073110d702fa85c18af21f234

This typo caused the following console error:

<img width="501" height="83" alt="スクリーンショット 2025-10-17 19 49 54" src="https://github.com/user-attachments/assets/270c7327-6291-4ed7-97fd-1a4cd5da4519" />

Due to this typo, the initialization function never executed properly.  
As a result, tracking events could not be sent.


