### PR TITLE
fix(google-maps): missing types for `<ScriptGoogleMaps/>`

### DIFF
--- a/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
+++ b/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
@@ -20,7 +20,7 @@ export const MAP_INJECTION_KEY = Symbol('map') as InjectionKey<{
 </script>
 
 <script lang="ts" setup>
-interface PlaceholderOptions {
+export interface PlaceholderOptions {
   width?: string | number
   height?: string | number
   center?: string


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The generated types for the `<ScriptGoogleMaps/>` is empty, see the `dist/runtime/components/GoogleMaps/ScriptGoogleMaps.d.vue.ts` file.

You can see the following error while building this module:

```sh
src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue(22,25): error TS4025: Exported variable '__VLS_export' has or is using private name 'PlaceholderOptions'.
```

Based on this error I exported the `PlaceholderOptions` in the component, which resolves the error and type generation.

This behavior is not present in the playground setup, since it is directly importing source code instead of using a stub/build/package. There may be other functionality that work in the playground that differ in actual projects, this issue in particular is an outlier in that it logs an error during build.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
