### PR TITLE
fix(plausible): use consistent window reference in clientInit stub

### DIFF
--- a/src/runtime/registry/plausible-analytics.ts
+++ b/src/runtime/registry/plausible-analytics.ts
@@ -181,12 +181,14 @@ export function useScriptPlausibleAnalytics<T extends PlausibleAnalyticsApi>(_op
         use() {
           return { plausible: window.plausible }
         },
-        clientInit() {
-          // @ts-expect-error untyped
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions,@stylistic/max-statements-per-line,prefer-rest-params
-          window.plausible = window.plausible || function () { (plausible.q = plausible.q || []).push(arguments) }, plausible.init = plausible.init || function (i) { plausible.o = i || {} }
-          window.plausible.init(initOptions)
-        },
+        clientInit: import.meta.server
+          ? undefined
+          : () => {
+              const w = window as any
+              w.plausible = w.plausible || function () { (w.plausible.q = w.plausible.q || []).push(arguments) }
+              w.plausible.init = w.plausible.init || function (i: PlausibleInitOptions) { w.plausible.o = i || {} }
+              w.plausible.init(initOptions)
+            },
       },
     }
   }, _options)


### PR DESCRIPTION
## 🔗 Linked issue

Resolves #543

## ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

## 📚 Description

The `clientInit` stub for Plausible Analytics was using bare `plausible` identifier mixed with `window.plausible`, which can cause issues in ES module scope where identifier resolution differs from non-module scripts.
