### PR TITLE
fix(google-maps): static maps proxy, color mode, and bug fixes

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,6 +3,7 @@ import {
   addComponentsDir,
   addImports,
   addPluginTemplate,
+  addServerHandler,
   addTemplate,
   createResolver,
   defineNuxtModule,
@@ -79,6 +80,22 @@ export interface ModuleOptions {
     integrity?: boolean | 'sha256' | 'sha384' | 'sha512'
   }
   /**
+   * Google Static Maps proxy configuration.
+   * Proxies static map images through your server to fix CORS issues and enable caching.
+   */
+  googleStaticMapsProxy?: {
+    /**
+     * Enable proxying Google Static Maps through your own origin.
+     * @default false
+     */
+    enabled?: boolean
+    /**
+     * Cache duration for static map images in seconds.
+     * @default 3600 (1 hour)
+     */
+    cacheMaxAge?: number
+  }
+  /**
    * Whether the module is enabled.
    *
    * @default true
@@ -115,6 +132,10 @@ export default defineNuxtModule<ModuleOptions>({
         timeout: 15_000, // Configures the maximum time (in milliseconds) allowed for each fetch attempt.
       },
     },
+    googleStaticMapsProxy: {
+      enabled: false,
+      cacheMaxAge: 3600,
+    },
     enabled: true,
     debug: false,
   },
@@ -136,11 +157,21 @@ export default defineNuxtModule<ModuleOptions>({
     if (unheadVersion?.startsWith('1')) {
       logger.error(`Nuxt Scripts requires Unhead >= 2, you are using v${unheadVersion}. Please run \`nuxi upgrade --clean\` to upgrade...`)
     }
-    nuxt.options.runtimeConfig['nuxt-scripts'] = { version }
+    nuxt.options.runtimeConfig['nuxt-scripts'] = {
+      version,
+      // Private proxy config with API key (server-side only)
+      googleStaticMapsProxy: config.googleStaticMapsProxy?.enabled
+        ? { apiKey: (nuxt.options.runtimeConfig.public.scripts as any)?.googleMaps?.apiKey }
+        : undefined,
+    }
     nuxt.options.runtimeConfig.public['nuxt-scripts'] = {
       // expose for devtools
       version: nuxt.options.dev ? version : undefined,
       defaultScriptOptions: config.defaultScriptOptions,
+      // Only expose enabled and cacheMaxAge to client, not apiKey
+      googleStaticMapsProxy: config.googleStaticMapsProxy?.enabled
+        ? { enabled: true, cacheMaxAge: config.googleStaticMapsProxy.cacheMaxAge }
+        : undefined,
     }
 
     // Merge registry config with existing runtimeConfig.public.scripts for proper env var resolution
@@ -249,6 +280,14 @@ export default defineNuxtModule<ModuleOptions>({
           await p?.()
       })
     })
+
+    // Add Google Static Maps proxy handler if enabled
+    if (config.googleStaticMapsProxy?.enabled) {
+      addServerHandler({
+        route: '/_scripts/google-static-maps-proxy',
+        handler: await resolvePath('./runtime/server/google-static-maps-proxy'),
+      })
+    }
 
     if (nuxt.options.dev)
       setupDevToolsUI(config, resolvePath)

--- a/src/runtime/components/GoogleMaps/ScriptGoogleMapsPinElement.vue
+++ b/src/runtime/components/GoogleMaps/ScriptGoogleMapsPinElement.vue
@@ -2,7 +2,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject, shallowRef } from 'vue'
+import { inject, onUnmounted, shallowRef } from 'vue'
 import { whenever } from '@vueuse/core'
 import { MAP_INJECTION_KEY } from './ScriptGoogleMaps.vue'
 import { ADVANCED_MARKER_ELEMENT_INJECTION_KEY } from './ScriptGoogleMapsAdvancedMarkerElement.vue'
@@ -42,4 +42,12 @@ whenever(
     once: true,
   },
 )
+
+onUnmounted(() => {
+  if (advancedMarkerElementContext?.advancedMarkerElement.value && pinElement.value) {
+    // Clear the content from the parent marker
+    advancedMarkerElementContext.advancedMarkerElement.value.content = null
+  }
+  pinElement.value = undefined
+})
 </script>

--- a/src/runtime/server/google-static-maps-proxy.ts
+++ b/src/runtime/server/google-static-maps-proxy.ts
@@ -1,0 +1,67 @@
+import { createError, defineEventHandler, getHeader, getQuery, setHeader } from 'h3'
+import { $fetch } from 'ofetch'
+import { withQuery } from 'ufo'
+import { useRuntimeConfig } from '#imports'
+
+export default defineEventHandler(async (event) => {
+  const runtimeConfig = useRuntimeConfig()
+  const publicConfig = (runtimeConfig.public['nuxt-scripts'] as any)?.googleStaticMapsProxy
+  const privateConfig = (runtimeConfig['nuxt-scripts'] as any)?.googleStaticMapsProxy
+
+  if (!publicConfig?.enabled) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Google Static Maps proxy is not enabled',
+    })
+  }
+
+  // Get API key from private config (server-side only, not exposed to client)
+  const apiKey = privateConfig?.apiKey
+  if (!apiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Google Maps API key not configured for proxy',
+    })
+  }
+
+  // Validate referer to prevent external abuse
+  const referer = getHeader(event, 'referer')
+  const host = getHeader(event, 'host')
+  if (referer && host) {
+    const refererUrl = new URL(referer).host
+    if (refererUrl !== host) {
+      throw createError({
+        statusCode: 403,
+        statusMessage: 'Invalid referer',
+      })
+    }
+  }
+
+  const query = getQuery(event)
+
+  // Remove any client-provided key and use server-side key
+  const { key: _clientKey, ...safeQuery } = query
+
+  const googleMapsUrl = withQuery('https://maps.googleapis.com/maps/api/staticmap', {
+    ...safeQuery,
+    key: apiKey,
+  })
+
+  const response = await $fetch.raw(googleMapsUrl, {
+    headers: {
+      'User-Agent': 'Nuxt Scripts Google Static Maps Proxy',
+    },
+  }).catch((error: any) => {
+    throw createError({
+      statusCode: error.statusCode || 500,
+      statusMessage: error.statusMessage || 'Failed to fetch static map',
+    })
+  })
+
+  const cacheMaxAge = publicConfig.cacheMaxAge || 3600
+  setHeader(event, 'Content-Type', response.headers.get('content-type') || 'image/png')
+  setHeader(event, 'Cache-Control', `public, max-age=${cacheMaxAge}, s-maxage=${cacheMaxAge}`)
+  setHeader(event, 'Vary', 'Accept-Encoding')
+
+  return response._data
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #380, #83, #539, #540
Supersedes #516

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Google Maps had several pain points: CORS issues with static map placeholders when using `crossOriginEmbedderPolicy`, no way to switch map styles based on color mode, and MarkerClusterer types breaking builds when the package wasn't installed.

Added a server-side static maps proxy that serves images from same origin (fixing CORS) with caching to reduce API costs. The proxy keeps the API key server-side only and validates referer headers to prevent abuse. Added `mapIds` prop to switch between light/dark Map IDs reactively when color mode changes. Replaced top-level type imports with inline types so MarkerClusterer is truly optional. Also fixed PinElement memory leak and importLibrary cache not retrying on failure.

```ts
// Static maps proxy - API key stays server-side
scripts: {
  googleStaticMapsProxy: { enabled: true, cacheMaxAge: 3600 }
}
```

```vue
<!-- Color mode support -->
<ScriptGoogleMaps :map-ids="{ light: 'LIGHT_ID', dark: 'DARK_ID' }" />
```