### PR TITLE
fix(posthog): 'history_change' as a capture_pageview option

### DIFF
--- a/docs/content/scripts/analytics/posthog.md
+++ b/docs/content/scripts/analytics/posthog.md
@@ -106,7 +106,7 @@ export const PostHogOptions = object({
   region: optional(union([literal('us'), literal('eu')])),
   apiHost: optional(string()), // Custom API host URL (e.g. '/ph' for reverse proxy)
   autocapture: optional(boolean()),
-  capturePageview: optional(boolean()),
+  capturePageview: optional(union([boolean(), literal('history_change')])),
   capturePageleave: optional(boolean()),
   disableSessionRecording: optional(boolean()),
   config: optional(record(string(), any())), // Full PostHogConfig passthrough

--- a/src/runtime/registry/posthog.ts
+++ b/src/runtime/registry/posthog.ts
@@ -9,7 +9,7 @@ export const PostHogOptions = object({
   region: optional(union([literal('us'), literal('eu')])),
   apiHost: optional(string()),
   autocapture: optional(boolean()),
-  capturePageview: optional(boolean()),
+  capturePageview: optional(union([boolean(), literal('history_change')])),
   capturePageleave: optional(boolean()),
   disableSessionRecording: optional(boolean()),
   config: optional(record(string(), any())),
@@ -90,7 +90,7 @@ export function useScriptPostHog<T extends PostHogApi>(_options?: PostHogInput) 
               }
               if (typeof options?.autocapture === 'boolean')
                 config.autocapture = options.autocapture
-              if (typeof options?.capturePageview === 'boolean')
+              if (typeof options?.capturePageview === 'boolean' || options?.capturePageview === 'history_change')
                 config.capture_pageview = options.capturePageview
               if (typeof options?.capturePageleave === 'boolean')
                 config.capture_pageleave = options.capturePageleave


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

For SPAs (most Nuxt apps) when the user wants pageview events captured they need to pass `history_change` as the option to posthog.

Without nuxt/scripts accepting this, a user would have to resort to using the config param and pass raw options instead, despite this being a _native_ one.

See posthog docs, [here](https://github.com/PostHog/posthog.com/blob/d8b89dea43826a03e2e95029a6872831a1a80a00/contents/docs/libraries/js/config.mdx?plain=1#L41)