### PR TITLE
fix: npm-mode registry scripts stored at $$scripts instead of $scripts

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -205,7 +205,7 @@ export function templatePlugin(config: Partial<ModuleOptions>, registry: Require
     `  parallel: true,`,
     `  setup() {`,
     ...inits.map(i => `    ${i}`),
-    `    return { provide: { $scripts: { ${[...Object.keys(config.globals || {}), ...resolvedRegistryKeys].join(', ')} } } }`,
+    `    return { provide: { scripts: { ${[...Object.keys(config.globals || {}), ...resolvedRegistryKeys].join(', ')} } } }`,
     `  }`,
     `})`,
   ].join('\n')


### PR DESCRIPTION
## Summary

- Fixes a bug where npm-mode registry scripts (e.g. PostHog) were silently stored at `nuxtApp.$$scripts` instead of `nuxtApp.$scripts`, making them inaccessible via the typed API

## Root Cause

Nuxt's plugin `provide` mechanism automatically prepends `$` to every key. The generated plugin was returning `{ provide: { $scripts: ... } }` — with an explicit `$` already in the key — causing Nuxt to double it to `$$scripts`.

## Fix

Remove the extra `$` from the generated provide key (Option A as suggested by @harlan-zw):

```diff
- return { provide: { $scripts: { ... } } }
+ return { provide: { scripts: { ... } } }
```

Nuxt's `provide` then adds `$` → `$scripts` ✓

No type changes needed — the type declaration already correctly declares `NuxtApp.$scripts`.

Closes #622