### PR TITLE
fix(posthog): unwrap array registry entry before injecting firstParty apiHost

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -599,8 +599,9 @@ export default defineNuxtModule<ModuleOptions>({
         // Auto-inject apiHost for PostHog when first-party proxy is enabled
         // PostHog uses NPM mode so URL rewrites don't apply - we set api_host via config instead
         if (config.registry?.posthog && typeof config.registry.posthog === 'object') {
-          const phConfig = config.registry.posthog as Record<string, any>
-          if (!phConfig.apiHost) {
+          // Registry entries can be in array form [inputOptions, scriptOptions] — unwrap to get the actual PostHog input options
+          const phConfig = (Array.isArray(config.registry.posthog) ? config.registry.posthog[0] : config.registry.posthog) as Record<string, any>
+          if (phConfig && !phConfig.apiHost) {
             const region = phConfig.region || 'us'
             phConfig.apiHost = region === 'eu'
               ? `${firstPartyCollectPrefix}/ph-eu`


### PR DESCRIPTION
## Summary

When \`scripts.registry.posthog\` is configured in array form \`[inputOptions, scriptOptions]\` — the documented way to pass both input options and script options (e.g. \`trigger: 'manual'\`) together — \`firstParty\` mode silently fails to inject \`apiHost\` into the PostHog configuration. PostHog falls back to calling \`eu.i.posthog.com\` / \`us.i.posthog.com\` directly, bypassing the first-party proxy entirely.

## Root cause

The injection code in \`src/module.ts\` (~L599) checks \`typeof config.registry.posthog === 'object'\`, which is \`true\` for arrays. It then reads and mutates the value directly as if it were the PostHog input options:

```ts
const phConfig = config.registry.posthog as Record<string, any>
if (!phConfig.apiHost) {
  phConfig.apiHost = ...  // sets property on the array, not on array[0]
}
```

When \`posthog\` is \`[inputOptions, scriptOptions]\`, \`phConfig\` is the array itself. \`phConfig.apiHost\` is \`undefined\` on the array, the condition passes, and \`apiHost\` is written to the array object — not to \`array[0]\` where the PostHog input options live.

The registry template generation in \`src/templates.ts\` already handles this correctly:

```ts
// src/templates.ts ~L127
else if (Array.isArray(c) && c.length === 2) {
  // [input, options] format - unpack properly
  const input = c[0] || {}
  ...
}
```

The firstParty injection in \`src/module.ts\` was missing the equivalent unwrap.

## Fix

Unwrap the array before reading/writing \`apiHost\`:

```ts
const phConfig = (Array.isArray(config.registry.posthog)
  ? config.registry.posthog[0]
  : config.registry.posthog) as Record<string, any>
```

## Repro

```ts
// nuxt.config.ts
export default defineNuxtConfig({
  scripts: {
    firstParty: true,
    registry: {
      posthog: [
        { apiKey: 'phc_xxx', region: 'eu' },
        { trigger: 'manual' },
      ],
    },
  },
})
```

With this config, PostHog sends events to \`eu.i.posthog.com\` directly instead of \`/_proxy/ph-eu\`. Verified with a Playwright network assertion test.

## Workaround (until fixed)

Explicitly set \`apiHost\` in the input options:

```ts
posthog: [
  { apiKey: 'phc_xxx', apiHost: '/_proxy/ph-eu', region: 'eu' },
  { trigger: 'manual' },
],
```

🤖 Generated with [Claude Code](https://claude.ai/code)