### PR TITLE
fix(posthog): expose Partial<PostHogConfig> on config field

### DIFF
--- a/src/runtime/registry/posthog.ts
+++ b/src/runtime/registry/posthog.ts
@@ -15,7 +15,13 @@ export const PostHogOptions = object({
   config: optional(record(string(), any())),
 })
 
-export type PostHogInput = RegistryScriptInput<typeof PostHogOptions, false, true>
+export type PostHogInput = Omit<RegistryScriptInput<typeof PostHogOptions, false, true>, 'config'> & {
+  /**
+   * Additional PostHog configuration options passed directly to `posthog.init()`.
+   * @see https://posthog.com/docs/libraries/js/config
+   */
+  config?: Partial<PostHogConfig>
+}
 
 export interface PostHogApi {
   posthog: PostHog


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

N/A

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Override PostHogInput.config type to Partial<PostHogConfig> so users get full PostHog option autocomplete via the config escape hatch, rather than the generic Record<string, any> inferred from the valibot schema.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
