### PR TITLE
fix(types): add googleSignIn to ScriptRegistry

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -14,6 +14,7 @@ import type { GoogleAdsenseInput } from './registry/google-adsense'
 import type { GoogleAnalyticsInput } from './registry/google-analytics'
 import type { GoogleMapsInput } from './registry/google-maps'
 import type { GoogleRecaptchaInput } from './registry/google-recaptcha'
+import type { GoogleSignInInput } from './registry/google-sign-in'
 import type { GoogleTagManagerInput } from './registry/google-tag-manager'
 import type { HotjarInput } from './registry/hotjar'
 import type { IntercomInput } from './registry/intercom'
@@ -168,6 +169,7 @@ export interface ScriptRegistry {
   googleAnalytics?: GoogleAnalyticsInput
   googleMaps?: GoogleMapsInput
   googleRecaptcha?: GoogleRecaptchaInput
+  googleSignIn?: GoogleSignInInput
   lemonSqueezy?: LemonSqueezyInput
   googleTagManager?: GoogleTagManagerInput
   hotjar?: HotjarInput


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

N/A

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

GoogleSignIn was missing from the ScriptRegistry interface in runtime/types.ts despite having a full registry implementation.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
