### PR TITLE
fix: allow custom script keys in ScriptRegistry type

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -192,13 +192,12 @@ export interface ScriptRegistry {
   umamiAnalytics?: UmamiAnalyticsInput
   gravatar?: GravatarInput
   [key: `${string}-npm`]: NpmInput
-  [key: string]: any
 }
 
 export type NuxtConfigScriptRegistryEntry<T> = true | 'mock' | T | [T, NuxtUseScriptOptionsSerializable]
 export type NuxtConfigScriptRegistry<T extends keyof ScriptRegistry = keyof ScriptRegistry> = Partial<{
   [key in T]: NuxtConfigScriptRegistryEntry<ScriptRegistry[key]>
-}>
+}> & Record<string & {}, NuxtConfigScriptRegistryEntry<any>>
 
 export type UseFunctionType<T, U> = T extends {
   use: infer V


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #581

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Custom scripts registered via the `scripts:registry` hook caused TypeScript errors in `nuxt.config` because `ScriptRegistry` only contained built-in keys. Adds `Record<string & {}, any>` intersection to `NuxtConfigScriptRegistry` (not `ScriptRegistry` itself, which would break `keyof`) so custom script keys are accepted while preserving autocomplete for built-in scripts.