### PR TITLE
feat: auto-populate runtimeConfig for .env registry script overrides

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -400,7 +400,7 @@ export default defineNuxtModule<ModuleOptions>({
             registryWithDefaults[key] = defu(value, envDefaults)
           }
           else if (Array.isArray(value)) {
-            registryWithDefaults[key] = [defu(value[0] || {}, envDefaults), value[1]]
+            registryWithDefaults[key] = defu(value[0] || {}, envDefaults)
           }
           else {
             registryWithDefaults[key] = value


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #239

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Users had to manually define verbose `runtimeConfig.public.scripts` entries for .env overrides to work with registry scripts. The module now auto-populates runtimeConfig defaults (empty string keys) when a registry script is enabled, so `NUXT_PUBLIC_SCRIPTS_GOOGLE_ANALYTICS_ID` works without any runtimeConfig boilerplate.