### PR TITLE
fix: avoid mutating runtimeConfig scriptOptions

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -83,7 +83,7 @@ export function useRegistryScript<T extends Record<string | symbol, any>, O = Em
   }
 
   const scriptInput = defu(finalScriptInput, userOptions.scriptInput, { key: registryKey }) as any as UseScriptInput
-  const scriptOptions = Object.assign(userOptions?.scriptOptions || {}, options.scriptOptions || {})
+  const scriptOptions = { ...userOptions?.scriptOptions, ...options.scriptOptions }
   if (import.meta.dev) {
     // Capture where the component was loaded from
     const error = new Error('Stack trace for component location')

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -14,6 +14,21 @@ vi.mock('#nuxt-scripts-validator', () => ({
   parse: vi.fn(),
 }))
 
+describe('useRegistryScript scriptOptions', () => {
+  it('should not mutate user-provided scriptOptions', () => {
+    const mockOptionsFunction = vi.fn((_opts, _ctx) => ({
+      scriptInput: { src: 'https://example.com/script.js' },
+      scriptOptions: { use: () => ({ test: true }) },
+    }))
+
+    const userScriptOptions = { trigger: 'onNuxtReady' as const }
+    const userOptions = { scriptOptions: userScriptOptions }
+    useRegistryScript('test', mockOptionsFunction, userOptions)
+
+    expect(userScriptOptions).not.toHaveProperty('use')
+  })
+})
+
 describe('useRegistryScript query param merging', () => {
   it('should merge query params when user provides custom src', () => {
     const mockOptionsFunction = vi.fn((_opts, _ctx) => ({


### PR DESCRIPTION
`useRegistryScript` uses `Object.assign(userOptions?.scriptOptions || {}, options.scriptOptions || {})` to merge script options. Since `Object.assign` mutates the first argument and `userOptions.scriptOptions` is a reference to the runtimeConfig object, registry-defined functions like `use()` get injected directly into `runtimeConfig.public.scripts.<key>.scriptOptions`. When Nuxt serializes the payload, devalue throws `Cannot stringify a function`.

Replaced `Object.assign` with object spread to create a new object instead of mutating the runtimeConfig reference.

This error is present in the latest stable and in the latest beta versions

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [scripts-devalue-use](https://stackblitz.com/github/onmax/repros/tree/repro/scripts-devalue-use/scripts-devalue-use?startScript=dev) | ❌ 500 "Cannot stringify a function" |
| Fix | [scripts-devalue-use-fix](https://stackblitz.com/github/onmax/repros/tree/repro/scripts-devalue-use/scripts-devalue-use-fix?startScript=dev) | ✅ Page renders |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/scripts-devalue-use https://github.com/onmax/repros.git
cd repros && git sparse-checkout set scripts-devalue-use
cd scripts-devalue-use && pnpm i && pnpm dev
# Visit http://localhost:3000 → 500 error
```

## Verify fix

```bash
git sparse-checkout add scripts-devalue-use-fix
cd ../scripts-devalue-use-fix && pnpm i && pnpm dev
# Visit http://localhost:3000 → page renders
```