### PR TITLE
fix(google-maps): use noDraw flag in AdvancedMarkerElement clusterer operations

### DIFF
--- a/src/runtime/components/GoogleMaps/ScriptGoogleMapsAdvancedMarkerElement.vue
+++ b/src/runtime/components/GoogleMaps/ScriptGoogleMapsAdvancedMarkerElement.vue
@@ -52,7 +52,8 @@ const advancedMarkerElement = useGoogleMapsResource<google.maps.marker.AdvancedM
     const marker = new mapsApi.marker.AdvancedMarkerElement(props.options)
     setupEventListeners(marker)
     if (markerClustererContext?.markerClusterer.value) {
-      markerClustererContext.markerClusterer.value.addMarker(marker)
+      markerClustererContext.markerClusterer.value.addMarker(marker, true)
+      markerClustererContext.requestRerender()
     }
     else {
       marker.map = map
@@ -62,7 +63,8 @@ const advancedMarkerElement = useGoogleMapsResource<google.maps.marker.AdvancedM
   cleanup(marker, { mapsApi }) {
     mapsApi.event.clearInstanceListeners(marker)
     if (markerClustererContext?.markerClusterer.value) {
-      markerClustererContext.markerClusterer.value.removeMarker(marker)
+      markerClustererContext.markerClusterer.value.removeMarker(marker, true)
+      markerClustererContext.requestRerender()
     }
     else {
       marker.map = null


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #652

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`ScriptGoogleMapsAdvancedMarkerElement` was calling `addMarker`/`removeMarker` on the MarkerClusterer without the `noDraw: true` flag, causing a full re-clustering cycle on every single marker addition. With ~2k markers this produced ~4k `clusteringbegin`/`clusteringend` event emissions and ~10s load times. Now uses `noDraw: true` + `requestRerender()` to batch into a single render — matching the existing pattern in `ScriptGoogleMapsMarker`.