### PR TITLE
feat: integrate Partytown with first-party proxy mode

### DIFF
--- a/src/first-party/index.ts
+++ b/src/first-party/index.ts
@@ -1,4 +1,5 @@
+export { generatePartytownResolveUrl } from './partytown-resolve'
 export { getAllProxyConfigs, PRIVACY_FULL, PRIVACY_HEATMAP, PRIVACY_IP_ONLY, PRIVACY_NONE, routesToInterceptRules } from './proxy-configs'
 export { finalizeFirstParty, setupFirstParty } from './setup'
-export type { FirstPartyConfig, FirstPartyDevtoolsData, FirstPartyDevtoolsScript } from './setup'
+export type { FinalizeFirstPartyResult, FirstPartyConfig, FirstPartyDevtoolsData, FirstPartyDevtoolsScript } from './setup'
 export type { FirstPartyOptions, FirstPartyPrivacy, InterceptRule, ProxyAutoInject, ProxyConfig, ProxyRewrite } from './types'

--- a/src/first-party/partytown-resolve.ts
+++ b/src/first-party/partytown-resolve.ts
@@ -1,0 +1,24 @@
+import type { InterceptRule } from './types'
+
+/**
+ * Generate a Partytown `resolveUrl` function string from first-party intercept rules.
+ * This is the web-worker equivalent of the intercept plugin — Partytown calls this
+ * for every network request (fetch, XHR, sendBeacon, Image, script) made by worker-executed scripts.
+ */
+export function generatePartytownResolveUrl(interceptRules: InterceptRule[]): string {
+  const rulesJson = JSON.stringify(interceptRules)
+  // Return raw function body as a string — @nuxtjs/partytown inlines this into a <script> tag.
+  // Must be self-contained with no external references.
+  return `function(url, location, type) {
+  var rules = ${rulesJson};
+  for (var i = 0; i < rules.length; i++) {
+    var rule = rules[i];
+    if (url.hostname === rule.pattern || url.hostname.endsWith('.' + rule.pattern)) {
+      if (rule.pathPrefix && !url.pathname.startsWith(rule.pathPrefix)) continue;
+      var path = rule.pathPrefix ? url.pathname.slice(rule.pathPrefix.length) : url.pathname;
+      var newPath = rule.target + (path.startsWith('/') ? '' : '/') + path + url.search;
+      return new URL(newPath, location.origin);
+    }
+  }
+}`
+}

--- a/src/first-party/setup.ts
+++ b/src/first-party/setup.ts
@@ -1,6 +1,6 @@
 import type { ProxyPrivacyInput } from '../runtime/server/utils/privacy'
 import type { BuiltInRegistryScriptKey, NuxtConfigScriptRegistry, RegistryScript, RegistryScriptKey } from '../runtime/types'
-import type { ProxyAutoInject, ProxyConfig } from './types'
+import type { InterceptRule, ProxyAutoInject, ProxyConfig } from './types'
 import { addPluginTemplate, addServerHandler } from '@nuxt/kit'
 import { logger } from '../logger'
 import { scriptMeta } from '../script-meta'
@@ -135,17 +135,22 @@ function computePrivacyLevel(privacy: Record<string, boolean>): 'full' | 'partia
   return 'none'
 }
 
+export interface FinalizeFirstPartyResult {
+  interceptRules: InterceptRule[]
+  devtools?: FirstPartyDevtoolsData
+}
+
 /**
  * Finalize first-party setup inside modules:done.
  * Uses pre-built proxyConfigs from setupFirstParty — no rebuild.
- * Returns devtools data when in dev mode.
+ * Returns intercept rules (for partytown resolveUrl) and devtools data.
  */
 export function finalizeFirstParty(opts: {
   firstParty: FirstPartyConfig
   registry: NuxtConfigScriptRegistry | undefined
   registryScripts: RegistryScript[]
   nuxtOptions: { dev: boolean, runtimeConfig: Record<string, any> }
-}): FirstPartyDevtoolsData | undefined {
+}): FinalizeFirstPartyResult {
   const { firstParty, registryScripts, nuxtOptions } = opts
   const { proxyConfigs, proxyPrefix } = firstParty
   const registryKeys = Object.keys(opts.registry || {})
@@ -292,7 +297,8 @@ export function finalizeFirstParty(opts: {
     )
   }
 
-  // Return devtools data in dev mode
+  // Build devtools data in dev mode
+  let devtools: FirstPartyDevtoolsData | undefined
   if (nuxtOptions.dev) {
     const allDomains = new Set<string>()
     for (const s of devtoolsScripts) {
@@ -300,7 +306,7 @@ export function finalizeFirstParty(opts: {
         allDomains.add(d)
     }
 
-    return {
+    devtools = {
       enabled: true,
       proxyPrefix,
       privacyMode: privacyLabel,
@@ -309,4 +315,6 @@ export function finalizeFirstParty(opts: {
       totalDomains: allDomains.size,
     }
   }
+
+  return { interceptRules, devtools }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -25,7 +25,7 @@ import { resolve as resolvePath_ } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
 import { setupPublicAssetStrategy } from './assets'
 import { setupDevToolsUI } from './devtools'
-import { finalizeFirstParty, setupFirstParty } from './first-party'
+import { finalizeFirstParty, generatePartytownResolveUrl, setupFirstParty } from './first-party'
 import { installNuxtModule } from './kit'
 import { logger } from './logger'
 import { normalizeRegistryConfig } from './normalize'
@@ -485,7 +485,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       // Finalize first-party proxy setup
       if (firstParty.enabled) {
-        const devtoolsData = finalizeFirstParty({
+        const { interceptRules, devtools: devtoolsData } = finalizeFirstParty({
           firstParty,
           registry: config.registry,
           registryScripts,
@@ -494,6 +494,18 @@ export default defineNuxtModule<ModuleOptions>({
         // Expose first-party data for devtools
         if (devtoolsData) {
           nuxt.options.runtimeConfig.public['nuxt-scripts-devtools'] = devtoolsData as any
+        }
+        // Auto-configure Partytown resolveUrl for first-party proxy
+        if (config.partytown?.length && hasNuxtModule('@nuxtjs/partytown') && interceptRules.length) {
+          const partytownConfig = (nuxt.options as any).partytown || {}
+          if (!partytownConfig.resolveUrl) {
+            partytownConfig.resolveUrl = generatePartytownResolveUrl(interceptRules)
+            ;(nuxt.options as any).partytown = partytownConfig
+            logger.info('[partytown] Auto-configured resolveUrl for first-party proxy')
+          }
+          else {
+            logger.warn('[partytown] Custom resolveUrl already set — first-party proxy URLs will not be auto-rewritten in Partytown worker. Add first-party proxy rules to your resolveUrl manually.')
+          }
         }
       }
 
@@ -507,6 +519,7 @@ export default defineNuxtModule<ModuleOptions>({
         registryConfig: nuxt.options.runtimeConfig.public.scripts as Record<string, any> | undefined,
         defaultBundle: firstParty.enabled || config.defaultScriptOptions?.bundle,
         proxyConfigs: firstParty.proxyConfigs,
+        partytownScripts: new Set(config.partytown || []),
         moduleDetected(module) {
           if (nuxt.options.dev && module !== '@nuxt/scripts' && !moduleInstallPromises.has(module) && !hasNuxtModule(module))
             moduleInstallPromises.set(module, () => installNuxtModule(module))

--- a/src/plugins/rewrite-ast.ts
+++ b/src/plugins/rewrite-ast.ts
@@ -195,7 +195,7 @@ function resolveCalleeTarget(callee: any, scopeTracker: ScopeTracker): string | 
  * Uses oxc-walker with ScopeTracker to precisely identify string literals,
  * resolve aliased globals, and rewrite API calls through the proxy.
  */
-export function rewriteScriptUrlsAST(content: string, filename: string, rewrites: ProxyRewrite[], postProcess?: (output: string, rewrites: ProxyRewrite[]) => string): string {
+export function rewriteScriptUrlsAST(content: string, filename: string, rewrites: ProxyRewrite[], postProcess?: (output: string, rewrites: ProxyRewrite[]) => string, options?: { skipApiRewrites?: boolean }): string {
   const s = new MagicString(content)
 
   // In minified JS, keywords like `return` can directly precede string literals
@@ -271,8 +271,8 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
         }
       }
 
-      // API call rewriting
-      if (node.type === 'CallExpression') {
+      // API call rewriting — skip for partytown scripts (they use resolveUrl instead)
+      if (node.type === 'CallExpression' && !options?.skipApiRewrites) {
         const callee = (node as any).callee
 
         // Canvas fingerprinting neutralization — only affects downloaded third-party scripts.
@@ -341,7 +341,7 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
       }
 
       // new XMLHttpRequest / new Image / new x.XMLHttpRequest / new x.Image
-      if (node.type === 'NewExpression') {
+      if (node.type === 'NewExpression' && !options?.skipApiRewrites) {
         const callee = (node as any).callee
 
         // new XMLHttpRequest — check it's truly global

--- a/src/plugins/transform.ts
+++ b/src/plugins/transform.ts
@@ -80,6 +80,12 @@ export interface AssetBundlerTransformerOptions {
    */
   integrity?: boolean | IntegrityAlgorithm
   renderedScript?: Map<string, RenderedScriptMeta | Error>
+  /**
+   * Set of registry script keys that use Partytown.
+   * Scripts in this set skip API call rewrites (__nuxtScripts.*) since Partytown's
+   * resolveUrl hook handles network interception in the web worker instead.
+   */
+  partytownScripts?: Set<string>
 }
 
 function normalizeScriptData(src: string, assetsBaseURL: string = '/_scripts/assets'): { url: string, filename?: string } {
@@ -106,8 +112,9 @@ async function downloadScript(opts: {
   proxyRewrites?: ProxyRewrite[]
   postProcess?: ProxyConfig['postProcess']
   integrity?: boolean | IntegrityAlgorithm
+  skipApiRewrites?: boolean
 }, renderedScript: NonNullable<AssetBundlerTransformerOptions['renderedScript']>, fetchOptions?: FetchOptions, cacheMaxAge?: number) {
-  const { src, url, filename, forceDownload, integrity, proxyRewrites, postProcess } = opts
+  const { src, url, filename, forceDownload, integrity, proxyRewrites, postProcess, skipApiRewrites } = opts
   if (src === url || !filename) {
     return
   }
@@ -151,7 +158,7 @@ async function downloadScript(opts: {
     // Apply URL rewrites for proxy mode (AST-based at build time)
     if (proxyRewrites?.length && res) {
       const content = res.toString('utf-8')
-      const rewritten = rewriteScriptUrlsAST(content, filename || 'script.js', proxyRewrites, postProcess)
+      const rewritten = rewriteScriptUrlsAST(content, filename || 'script.js', proxyRewrites, postProcess, { skipApiRewrites })
       res = Buffer.from(rewritten, 'utf-8')
       logger.debug(`Rewrote ${proxyRewrites.length} URL patterns in ${filename}`)
     }
@@ -424,12 +431,13 @@ export function NuxtScriptBundleTransformer(options: AssetBundlerTransformerOpti
                       : undefined
                     const proxyRewrites = proxyConfig?.rewrite
                     const postProcess = proxyConfig?.postProcess
+                    const skipApiRewrites = !!(registryKey && options.partytownScripts?.has(registryKey))
 
                     // Defer async download + MagicString operations
                     deferredOps.push(async () => {
                       let url = _url
                       try {
-                        await downloadScript({ src: src as string, url, filename, forceDownload, proxyRewrites, postProcess, integrity: options.integrity }, renderedScript, options.fetchOptions, options.cacheMaxAge)
+                        await downloadScript({ src: src as string, url, filename, forceDownload, proxyRewrites, postProcess, integrity: options.integrity, skipApiRewrites }, renderedScript, options.fetchOptions, options.cacheMaxAge)
                       }
                       catch (e: any) {
                         if (options.fallbackOnSrcOnBundleFail) {

--- a/test/unit/rewrite-ast.test.ts
+++ b/test/unit/rewrite-ast.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getAllProxyConfigs } from '../../src/first-party'
+import { generatePartytownResolveUrl, getAllProxyConfigs } from '../../src/first-party'
 import { rewriteScriptUrlsAST } from '../../src/plugins/rewrite-ast'
 
 const rewrites = [
@@ -231,5 +231,122 @@ describe('rewriteScriptUrlsAST', () => {
     it('rewrites navigator.sendBeacon', () => {
       expect(rewrite('navigator.sendBeacon("https://example.com/collect", data)')).toContain('__nuxtScripts.sendBeacon')
     })
+  })
+
+  describe('skipApiRewrites (partytown mode)', () => {
+    function rewritePartytown(code: string): string {
+      return rewriteScriptUrlsAST(code, 'test.js', rewrites, undefined, { skipApiRewrites: true })
+    }
+
+    it('still rewrites URL string literals', () => {
+      expect(rewritePartytown('"https://example.com/api"')).toContain('self.location.origin+"/_proxy/ex/api"')
+    })
+
+    it('skips fetch rewriting', () => {
+      const result = rewritePartytown('fetch("https://example.com/api")')
+      expect(result).not.toContain('__nuxtScripts')
+      expect(result).toContain('fetch(')
+      // URL literal is still rewritten
+      expect(result).toContain('self.location.origin+"/_proxy/ex/api"')
+    })
+
+    it('skips navigator.sendBeacon rewriting', () => {
+      const result = rewritePartytown('navigator.sendBeacon("https://example.com/collect", data)')
+      expect(result).not.toContain('__nuxtScripts')
+      expect(result).toContain('navigator.sendBeacon(')
+    })
+
+    it('skips XMLHttpRequest rewriting', () => {
+      const result = rewritePartytown('var a = new XMLHttpRequest();')
+      expect(result).not.toContain('__nuxtScripts')
+      expect(result).toContain('new XMLHttpRequest()')
+    })
+
+    it('skips Image rewriting', () => {
+      const result = rewritePartytown('var img = new Image();')
+      expect(result).not.toContain('__nuxtScripts')
+      expect(result).toContain('new Image()')
+    })
+
+    it('skips canvas toDataURL neutralization', () => {
+      const result = rewritePartytown('ctx.canvas.toDataURL()')
+      expect(result).not.toContain('data:image/png')
+      expect(result).toContain('toDataURL()')
+    })
+  })
+})
+
+describe('generatePartytownResolveUrl', () => {
+  it('generates a valid function string', () => {
+    const rules = [
+      { pattern: 'www.google-analytics.com', pathPrefix: '', target: '/_scripts/p/ga' },
+    ]
+    const fn = generatePartytownResolveUrl(rules)
+    expect(fn).toContain('function(url, location, type)')
+    expect(fn).toContain('www.google-analytics.com')
+    expect(fn).toContain('/_scripts/p/ga')
+  })
+
+  it('embeds all rules as JSON', () => {
+    const rules = [
+      { pattern: 'www.google-analytics.com', pathPrefix: '', target: '/_scripts/p/ga' },
+      { pattern: 'www.facebook.com', pathPrefix: '/tr', target: '/_scripts/p/meta' },
+    ]
+    const fn = generatePartytownResolveUrl(rules)
+    expect(fn).toContain('"www.facebook.com"')
+    expect(fn).toContain('"/tr"')
+  })
+
+  it('returns undefined for non-matching URLs (no return statement for miss)', () => {
+    const rules = [{ pattern: 'example.com', pathPrefix: '', target: '/_scripts/p/ex' }]
+    const fn = generatePartytownResolveUrl(rules)
+    // eslint-disable-next-line no-new-func
+    const resolveUrl = new Function(`return ${fn}`)()
+    const url = new URL('https://other.com/path')
+    const location = new URL('https://mysite.com')
+    expect(resolveUrl(url, location, 'fetch')).toBeUndefined()
+  })
+
+  it('rewrites matching URLs to first-party proxy', () => {
+    const rules = [{ pattern: 'example.com', pathPrefix: '', target: '/_scripts/p/ex' }]
+    const fn = generatePartytownResolveUrl(rules)
+    // eslint-disable-next-line no-new-func
+    const resolveUrl = new Function(`return ${fn}`)()
+    const url = new URL('https://example.com/collect?v=1')
+    const location = new URL('https://mysite.com')
+    const result = resolveUrl(url, location, 'fetch')
+    expect(result).toBeInstanceOf(URL)
+    expect(result.pathname).toBe('/_scripts/p/ex/collect')
+    expect(result.search).toBe('?v=1')
+    expect(result.origin).toBe('https://mysite.com')
+  })
+
+  it('matches subdomains', () => {
+    const rules = [{ pattern: 'google-analytics.com', pathPrefix: '', target: '/_scripts/p/ga' }]
+    const fn = generatePartytownResolveUrl(rules)
+    // eslint-disable-next-line no-new-func
+    const resolveUrl = new Function(`return ${fn}`)()
+    const url = new URL('https://www.google-analytics.com/g/collect')
+    const location = new URL('https://mysite.com')
+    const result = resolveUrl(url, location, 'fetch')
+    expect(result.pathname).toBe('/_scripts/p/ga/g/collect')
+  })
+
+  it('respects pathPrefix matching', () => {
+    const rules = [{ pattern: 'www.facebook.com', pathPrefix: '/tr', target: '/_scripts/p/meta' }]
+    const fn = generatePartytownResolveUrl(rules)
+    // eslint-disable-next-line no-new-func
+    const resolveUrl = new Function(`return ${fn}`)()
+
+    // Matching path prefix
+    const url1 = new URL('https://www.facebook.com/tr?id=123')
+    const location = new URL('https://mysite.com')
+    const result1 = resolveUrl(url1, location, 'fetch')
+    expect(result1.pathname).toBe('/_scripts/p/meta/')
+    expect(result1.search).toBe('?id=123')
+
+    // Non-matching path prefix
+    const url2 = new URL('https://www.facebook.com/other')
+    expect(resolveUrl(url2, location, 'fetch')).toBeUndefined()
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Partytown and first-party proxy mode were completely separate code paths — Partytown scripts bypassed bundling/URL rewriting, and the intercept plugin (main-thread monkey-patches) couldn't reach Partytown's web worker. This meant scripts loaded from third-party domains and all tracking requests went unproxied.

This PR integrates the two via three points:

1. **`resolveUrl` generation** — generates a Partytown `resolveUrl` function from the same intercept rules used by the main-thread intercept plugin. This is the web-worker equivalent — Partytown calls it for every network request (fetch, XHR, sendBeacon, Image) made by worker-executed scripts.

2. **`skipApiRewrites` for partytown scripts** — when bundling scripts for Partytown, URL string literals are still rewritten but API call rewrites (`fetch` → `__nuxtScripts.fetch`, etc.) are skipped since `__nuxtScripts` doesn't exist in the worker context and `resolveUrl` handles interception instead.

3. **Auto-configuration** — after `finalizeFirstParty`, auto-configures `@nuxtjs/partytown`'s `resolveUrl` from the computed intercept rules. Warns if user already has a custom `resolveUrl`.

### Flow for a partytown + first-party script

1. **Build**: Script downloaded, URLs rewritten via AST (API calls left alone), served as bundled asset
2. **SSR**: `useScript` partytown quick-path renders `<script src="/_scripts/assets/bundled.js" type="text/partytown">` (src already rewritten by transform)
3. **Worker**: Partytown loads bundled script in worker. Static URLs already point to proxy. Dynamic URLs caught by `resolveUrl` → rewritten to `/_scripts/p/*`
4. **Server**: Nitro proxy handler forwards to third-party with privacy transforms

### Changed files

| File | Change |
|------|--------|
| `src/first-party/partytown-resolve.ts` | New — `generatePartytownResolveUrl()` |
| `src/first-party/setup.ts` | `finalizeFirstParty` returns `interceptRules` alongside devtools data |
| `src/first-party/index.ts` | Re-exports new function and type |
| `src/module.ts` | Auto-configures partytown `resolveUrl`, passes `partytownScripts` to transform |
| `src/plugins/rewrite-ast.ts` | `skipApiRewrites` option on `rewriteScriptUrlsAST` |
| `src/plugins/transform.ts` | Accepts `partytownScripts` set, passes `skipApiRewrites` for partytown scripts |
| `test/unit/rewrite-ast.test.ts` | Tests for `skipApiRewrites` + `generatePartytownResolveUrl` |