### PR TITLE
fix: add v0 migration warnings and docs for breaking config changes

### DIFF
--- a/docs/content/docs/1.guides/1.registry-scripts.md
+++ b/docs/content/docs/1.guides/1.registry-scripts.md
@@ -68,8 +68,7 @@ NUXT_PUBLIC_SCRIPTS_CLOUDFLARE_WEB_ANALYTICS_TOKEN=YOUR_TOKEN
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      // loads the script
-      cloudflareWebAnalytics: true,
+      cloudflareWebAnalytics: { trigger: 'onNuxtReady' },
     },
   },
   runtimeConfig: {
@@ -100,7 +99,7 @@ You can do this by providing a `mock` value to the registry script.
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      googleTagManager: true,
+      googleTagManager: { trigger: 'onNuxtReady' },
     },
   },
   $development: {

--- a/docs/content/docs/4.migration-guide/1.v0-to-v1.md
+++ b/docs/content/docs/4.migration-guide/1.v0-to-v1.md
@@ -192,15 +192,49 @@ Server-side geocoding proxy to reduce billing costs and hide API keys. Automatic
 
 v1 redesigns how registry entries work. The key change: **presence enables infrastructure, `trigger` enables auto-loading**.
 
+### Scripts No Longer Auto-Load Without a Trigger
+
+In v0, any configured script auto-loaded globally. In v1, scripts require an explicit `trigger` to auto-load. Without one, the script registers infrastructure (proxy routes, types, bundling) but does **not** load on the page.
+
+If you had a config like this in v0:
+
+```ts [v0 nuxt.config.ts]
+scripts: {
+  registry: {
+    googleAnalytics: { id: 'G-XXXXXX' },
+  }
+}
+```
+
+You need to add a trigger in v1:
+
+```ts [v1 nuxt.config.ts]
+scripts: {
+  registry: {
+    googleAnalytics: { id: 'G-XXXXXX', trigger: 'onNuxtReady' },
+  }
+}
+```
+
+Or use the `true` shorthand to auto-load with default settings:
+
+```ts
+googleAnalytics: true // auto-loads with trigger: 'onNuxtReady'
+```
+
+::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
+A build warning will appear if you provide config values without a `trigger`. This is intentional: in v1 you must opt in to auto-loading.
+::
+
 ### Config Migration
 
 | v0 | v1 | What changed |
 |----|-----|--------------|
+| `googleAnalytics: { id: '...' }` | `googleAnalytics: { id: '...', trigger: 'onNuxtReady' }` | Scripts no longer auto-load without an explicit `trigger` |
 | `googleAnalytics: true` | `googleAnalytics: true` | Still works; alias for `{ trigger: 'onNuxtReady' }` (auto-load). Use `{}` for proxy/bundling infrastructure without auto-loading |
-| `[{ id: '...' }, { bundle: true }]` | `{ id: '...' }` | Bundling is auto-enabled via capabilities; no need to opt in |
+| `[{ id: '...' }, { bundle: true }]` | `{ id: '...', trigger: 'onNuxtReady' }` | Bundling is auto-enabled via capabilities; add `trigger` to auto-load |
 | `[{ id: '...' }, { trigger: 'onNuxtReady' }]` | `{ id: '...', trigger: 'onNuxtReady' }` | Array tuple syntax still works, but flat config is preferred |
 | `googleAnalytics: 'mock'` | `googleAnalytics: 'mock'` | Unchanged; creates a stub for testing |
-| `{ reverseProxyIntercept: false }` | `{ proxy: false }` | Renamed; auto-migrated with a build warning |
 
 ### Flat Config Syntax
 

--- a/docs/content/docs/4.migration-guide/1.v0-to-v1.md
+++ b/docs/content/docs/4.migration-guide/1.v0-to-v1.md
@@ -63,9 +63,9 @@ Enable the embeds you need in your `nuxt.config`:
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      xEmbed: true,
-      instagramEmbed: true,
-      blueskyEmbed: true,
+      xEmbed: { trigger: 'onNuxtReady' },
+      instagramEmbed: { trigger: 'onNuxtReady' },
+      blueskyEmbed: { trigger: 'onNuxtReady' },
     },
   },
 })
@@ -220,20 +220,20 @@ export default defineNuxtConfig({
 })
 ```
 
-Or use the `true` shorthand to auto-load with default settings:
+If you only need infrastructure (proxy routes, types, bundling) without loading the script, set `trigger: false` explicitly:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      googleAnalytics: true, // auto-loads with trigger: 'onNuxtReady'
+      googleAnalytics: { id: 'G-XXXXXX', trigger: false },
     }
   }
 })
 ```
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-A build warning will appear if you provide config values without a `trigger`. This is intentional: in v1 you must opt in to auto-loading.
+A build warning will appear if you provide config values without a `trigger`. Set `trigger: 'onNuxtReady'` to auto-load, or `trigger: false` for infrastructure only.
 ::
 
 ### Config Migration
@@ -241,7 +241,7 @@ A build warning will appear if you provide config values without a `trigger`. Th
 | v0 | v1 | What changed |
 |----|-----|--------------|
 | `googleAnalytics: { id: '...' }` | `googleAnalytics: { id: '...', trigger: 'onNuxtReady' }` | Scripts no longer auto-load without an explicit `trigger` |
-| `googleAnalytics: true` | `googleAnalytics: true` | Still works; alias for `{ trigger: 'onNuxtReady' }` (auto-load). Use `{}` for proxy/bundling infrastructure without auto-loading |
+| `googleAnalytics: true` | `googleAnalytics: { trigger: 'onNuxtReady' }` | `true` shorthand is deprecated; use an explicit object with `trigger` |
 | `[{ id: '...' }, { bundle: true }]` | `{ id: '...', trigger: 'onNuxtReady' }` | Bundling is auto-enabled via capabilities; add `trigger` to auto-load |
 | `[{ id: '...' }, { trigger: 'onNuxtReady' }]` | `{ id: '...', trigger: 'onNuxtReady' }` | Array tuple syntax still works, but flat config is preferred |
 | `googleAnalytics: 'mock'` | `googleAnalytics: 'mock'` | Unchanged; creates a stub for testing |

--- a/docs/content/docs/4.migration-guide/1.v0-to-v1.md
+++ b/docs/content/docs/4.migration-guide/1.v0-to-v1.md
@@ -199,27 +199,37 @@ In v0, any configured script auto-loaded globally. In v1, scripts require an exp
 If you had a config like this in v0:
 
 ```ts [v0 nuxt.config.ts]
-scripts: {
-  registry: {
-    googleAnalytics: { id: 'G-XXXXXX' },
+export default defineNuxtConfig({
+  scripts: {
+    registry: {
+      googleAnalytics: { id: 'G-XXXXXX' },
+    }
   }
-}
+})
 ```
 
 You need to add a trigger in v1:
 
 ```ts [v1 nuxt.config.ts]
-scripts: {
-  registry: {
-    googleAnalytics: { id: 'G-XXXXXX', trigger: 'onNuxtReady' },
+export default defineNuxtConfig({
+  scripts: {
+    registry: {
+      googleAnalytics: { id: 'G-XXXXXX', trigger: 'onNuxtReady' },
+    }
   }
-}
+})
 ```
 
 Or use the `true` shorthand to auto-load with default settings:
 
-```ts
-googleAnalytics: true // auto-loads with trigger: 'onNuxtReady'
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  scripts: {
+    registry: {
+      googleAnalytics: true, // auto-loads with trigger: 'onNuxtReady'
+    }
+  }
+})
 ```
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}

--- a/docs/content/docs/4.migration-guide/1.v0-to-v1.md
+++ b/docs/content/docs/4.migration-guide/1.v0-to-v1.md
@@ -200,6 +200,7 @@ v1 redesigns how registry entries work. The key change: **presence enables infra
 | `[{ id: '...' }, { bundle: true }]` | `{ id: '...' }` | Bundling is auto-enabled via capabilities; no need to opt in |
 | `[{ id: '...' }, { trigger: 'onNuxtReady' }]` | `{ id: '...', trigger: 'onNuxtReady' }` | Array tuple syntax still works, but flat config is preferred |
 | `googleAnalytics: 'mock'` | `googleAnalytics: 'mock'` | Unchanged; creates a stub for testing |
+| `{ reverseProxyIntercept: false }` | `{ proxy: false }` | Renamed; auto-migrated with a build warning |
 
 ### Flat Config Syntax
 

--- a/docs/content/docs/4.migration-guide/1.v0-to-v1.md
+++ b/docs/content/docs/4.migration-guide/1.v0-to-v1.md
@@ -220,7 +220,7 @@ export default defineNuxtConfig({
 })
 ```
 
-If you only need infrastructure (proxy routes, types, bundling) without loading the script, set `trigger: false` explicitly:
+If you only need infrastructure without loading the script on the page, set `trigger: false` explicitly. This registers proxy routes, TypeScript types, and bundling config, but no `<script>`{lang="html"} tag is injected. Useful when you load the script yourself via a component or composable.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -240,11 +240,8 @@ A build warning will appear if you provide config values without a `trigger`. Se
 
 | v0 | v1 | What changed |
 |----|-----|--------------|
-| `googleAnalytics: { id: '...' }` | `googleAnalytics: { id: '...', trigger: 'onNuxtReady' }` | Scripts no longer auto-load without an explicit `trigger` |
-| `googleAnalytics: true` | `googleAnalytics: { trigger: 'onNuxtReady' }` | `true` shorthand is deprecated; use an explicit object with `trigger` |
-| `[{ id: '...' }, { bundle: true }]` | `{ id: '...', trigger: 'onNuxtReady' }` | Bundling is auto-enabled via capabilities; add `trigger` to auto-load |
-| `[{ id: '...' }, { trigger: 'onNuxtReady' }]` | `{ id: '...', trigger: 'onNuxtReady' }` | Array tuple syntax still works, but flat config is preferred |
-| `googleAnalytics: 'mock'` | `googleAnalytics: 'mock'` | Unchanged; creates a stub for testing |
+| `{ id: '...' }` | `{ id: '...', trigger: 'onNuxtReady' }` | Add an explicit `trigger` to auto-load. `true` shorthand, `bundle` option, and array tuple syntax are also replaced by flat config with `trigger`. |
+| `'mock'` | `'mock'` | Unchanged; creates a stub for testing |
 
 ### Flat Config Syntax
 

--- a/docs/content/scripts/crisp.md
+++ b/docs/content/scripts/crisp.md
@@ -107,7 +107,7 @@ If you prefer to configure your id using environment variables.
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      crisp: true,
+      crisp: { trigger: 'onNuxtReady' },
     }
   },
   // you need to provide a runtime config to access the environment variables

--- a/docs/content/scripts/google-maps/index.md
+++ b/docs/content/scripts/google-maps/index.md
@@ -36,7 +36,7 @@ Enable Google Maps in your `nuxt.config` and provide your API key via environmen
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      googleMaps: true,
+      googleMaps: { trigger: 'onNuxtReady' },
     },
   },
   runtimeConfig: {

--- a/docs/content/scripts/intercom.md
+++ b/docs/content/scripts/intercom.md
@@ -87,7 +87,7 @@ If you prefer to configure your app ID using environment variables.
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      intercom: true,
+      intercom: { trigger: 'onNuxtReady' },
     }
   },
   // you need to provide a runtime config to access the environment variables

--- a/docs/content/scripts/paypal.md
+++ b/docs/content/scripts/paypal.md
@@ -106,7 +106,7 @@ If you prefer to configure your client ID using environment variables.
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      paypal: true,
+      paypal: { trigger: 'onNuxtReady' },
     }
   },
   // you need to provide a runtime config to access the environment variables

--- a/docs/content/scripts/stripe.md
+++ b/docs/content/scripts/stripe.md
@@ -43,7 +43,7 @@ Stripe recommends loading their script globally on your app to improve fraud det
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      stripe: true,
+      stripe: { trigger: 'onNuxtReady' },
     }
   }
 })
@@ -54,7 +54,7 @@ export default defineNuxtConfig({
   $production: {
     scripts: {
       registry: {
-        stripe: true,
+        stripe: { trigger: 'onNuxtReady' },
       }
     }
   }

--- a/docs/content/scripts/vercel-analytics.md
+++ b/docs/content/scripts/vercel-analytics.md
@@ -34,7 +34,7 @@ First-party mode is auto-enabled for Vercel Analytics. Nuxt bundles the analytic
 export default defineNuxtConfig({
   scripts: {
     registry: {
-      vercelAnalytics: true,
+      vercelAnalytics: { trigger: 'onNuxtReady' },
     }
   }
 })

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -32,7 +32,7 @@ import { setupPublicAssetStrategy } from './assets'
 import { buildDevtoolsData, buildDevtoolsEntry, setupDevtools } from './devtools'
 import { installNuxtModule } from './kit'
 import { logger } from './logger'
-import { extractRequiredFields, normalizeRegistryConfig } from './normalize'
+import { extractRequiredFields, migrateDeprecatedRegistryKeys, normalizeRegistryConfig } from './normalize'
 import { NuxtScriptsCheckScripts } from './plugins/check-scripts'
 import { generateInterceptPluginContents } from './plugins/intercept'
 import { NuxtScriptBundleTransformer } from './plugins/transform'
@@ -332,6 +332,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Normalize registry entries to [input, scriptOptions?] tuple form
     // Eliminates 4-shape polymorphism (true | 'mock' | object | array) for all downstream consumers
     if (config.registry) {
+      migrateDeprecatedRegistryKeys(config.registry as Record<string, any>, msg => logger.warn(msg))
       normalizeRegistryConfig(config.registry as Record<string, any>)
       nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
 

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -32,7 +32,7 @@ import { setupPublicAssetStrategy } from './assets'
 import { buildDevtoolsData, buildDevtoolsEntry, setupDevtools } from './devtools'
 import { installNuxtModule } from './kit'
 import { logger } from './logger'
-import { extractRequiredFields, migrateDeprecatedRegistryKeys, normalizeRegistryConfig } from './normalize'
+import { extractRequiredFields, normalizeRegistryConfig } from './normalize'
 import { NuxtScriptsCheckScripts } from './plugins/check-scripts'
 import { generateInterceptPluginContents } from './plugins/intercept'
 import { NuxtScriptBundleTransformer } from './plugins/transform'
@@ -332,7 +332,6 @@ export default defineNuxtModule<ModuleOptions>({
     // Normalize registry entries to [input, scriptOptions?] tuple form
     // Eliminates 4-shape polymorphism (true | 'mock' | object | array) for all downstream consumers
     if (config.registry) {
-      migrateDeprecatedRegistryKeys(config.registry as Record<string, any>, msg => logger.warn(msg))
       normalizeRegistryConfig(config.registry as Record<string, any>)
       nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
 
@@ -459,6 +458,15 @@ export default defineNuxtModule<ModuleOptions>({
         const missing = requiredFields.filter(f => !input[f])
         if (missing.length) {
           logger.warn(`[nuxt-scripts] registry.${key}: missing required field${missing.length > 1 ? 's' : ''} ${missing.map(f => `'${f}'`).join(', ')}. The script infrastructure is registered but will not function without ${missing.length > 1 ? 'them' : 'it'}.`)
+        }
+        // Warn when a user provides input config but no trigger: the script won't auto-load.
+        // In v0 all configured scripts auto-loaded; in v1 a trigger is required.
+        if (Object.keys(input).length > 0 && !scriptOptions?.trigger) {
+          logger.warn(
+            `[nuxt-scripts] registry.${key}: config provided without a \`trigger\`. `
+            + `The script will not auto-load. Add \`trigger: 'onNuxtReady'\` to auto-load, or use \`true\` as a shorthand. `
+            + `See https://scripts.nuxt.com/docs/migration-guide/v0-to-v1`,
+          )
         }
       }
     }

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -332,7 +332,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Normalize registry entries to [input, scriptOptions?] tuple form
     // Eliminates 4-shape polymorphism (true | 'mock' | object | array) for all downstream consumers
     if (config.registry) {
-      normalizeRegistryConfig(config.registry as Record<string, any>)
+      normalizeRegistryConfig(config.registry as Record<string, any>, msg => logger.warn(msg))
       nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
 
       // Auto-populate env var defaults for enabled registry scripts so that
@@ -459,12 +459,13 @@ export default defineNuxtModule<ModuleOptions>({
         if (missing.length) {
           logger.warn(`[nuxt-scripts] registry.${key}: missing required field${missing.length > 1 ? 's' : ''} ${missing.map(f => `'${f}'`).join(', ')}. The script infrastructure is registered but will not function without ${missing.length > 1 ? 'them' : 'it'}.`)
         }
-        // Warn when a user provides input config but no trigger: the script won't auto-load.
+        // Warn when a user provides input config but no explicit trigger.
         // In v0 all configured scripts auto-loaded; in v1 a trigger is required.
-        if (Object.keys(input).length > 0 && !scriptOptions?.trigger) {
+        // trigger: false is valid (explicit infrastructure-only).
+        if (Object.keys(input).length > 0 && (!scriptOptions || !('trigger' in scriptOptions))) {
           logger.warn(
             `[nuxt-scripts] registry.${key}: config provided without a \`trigger\`. `
-            + `The script will not auto-load. Add \`trigger: 'onNuxtReady'\` to auto-load, or use \`true\` as a shorthand. `
+            + `The script will not auto-load. Add \`trigger: 'onNuxtReady'\` to auto-load, or \`trigger: false\` for infrastructure only. `
             + `See https://scripts.nuxt.com/docs/migration-guide/v0-to-v1`,
           )
         }

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -32,7 +32,7 @@ import { setupPublicAssetStrategy } from './assets'
 import { buildDevtoolsData, buildDevtoolsEntry, setupDevtools } from './devtools'
 import { installNuxtModule } from './kit'
 import { logger } from './logger'
-import { extractRequiredFields, normalizeRegistryConfig } from './normalize'
+import { extractRequiredFields, migrateDeprecatedRegistryKeys, normalizeRegistryConfig } from './normalize'
 import { NuxtScriptsCheckScripts } from './plugins/check-scripts'
 import { generateInterceptPluginContents } from './plugins/intercept'
 import { NuxtScriptBundleTransformer } from './plugins/transform'
@@ -332,6 +332,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Normalize registry entries to [input, scriptOptions?] tuple form
     // Eliminates 4-shape polymorphism (true | 'mock' | object | array) for all downstream consumers
     if (config.registry) {
+      migrateDeprecatedRegistryKeys(config.registry as Record<string, any>, msg => logger.warn(msg))
       normalizeRegistryConfig(config.registry as Record<string, any>, msg => logger.warn(msg))
       nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
 
@@ -462,7 +463,10 @@ export default defineNuxtModule<ModuleOptions>({
         // Warn when a user provides input config but no explicit trigger.
         // In v0 all configured scripts auto-loaded; in v1 a trigger is required.
         // trigger: false is valid (explicit infrastructure-only).
-        if (Object.keys(input).length > 0 && (!scriptOptions || !('trigger' in scriptOptions))) {
+        // Only warn for user-provided fields (skip env-var-only defaults).
+        const envDefaultKeys = new Set(Object.keys(script.envDefaults || {}))
+        const userProvidedFields = Object.keys(input).filter(f => !envDefaultKeys.has(f))
+        if (userProvidedFields.length > 0 && (!scriptOptions || !('trigger' in scriptOptions))) {
           logger.warn(
             `[nuxt-scripts] registry.${key}: config provided without a \`trigger\`. `
             + `The script will not auto-load. Add \`trigger: 'onNuxtReady'\` to auto-load, or \`trigger: false\` for infrastructure only. `

--- a/packages/script/src/normalize.ts
+++ b/packages/script/src/normalize.ts
@@ -40,7 +40,7 @@ export function migrateDeprecatedRegistryKeys(
       // Array tuple: check scriptOptions (second element)
       const opts = entry[1]
       if (opts && typeof opts === 'object' && 'reverseProxyIntercept' in opts) {
-        warn(`registry.${key}: \`reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
+        warn(`[nuxt-scripts] registry.${key}: \`reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
         const o = opts as Record<string, unknown>
         o.proxy ??= o.reverseProxyIntercept
         delete o.reverseProxyIntercept
@@ -50,14 +50,14 @@ export function migrateDeprecatedRegistryKeys(
       const obj = entry as Record<string, unknown>
       // Top-level key
       if ('reverseProxyIntercept' in obj) {
-        warn(`registry.${key}: \`reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
+        warn(`[nuxt-scripts] registry.${key}: \`reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
         obj.proxy ??= obj.reverseProxyIntercept
         delete obj.reverseProxyIntercept
       }
       // Nested scriptOptions
       const so = obj.scriptOptions
       if (so && typeof so === 'object' && 'reverseProxyIntercept' in so) {
-        warn(`registry.${key}: \`scriptOptions.reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
+        warn(`[nuxt-scripts] registry.${key}: \`scriptOptions.reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
         const s = so as Record<string, unknown>
         s.proxy ??= s.reverseProxyIntercept
         delete s.reverseProxyIntercept
@@ -92,7 +92,7 @@ export function normalizeRegistryConfig(
       continue
     }
     if (entry === true) {
-      warn?.(`registry.${key}: \`true\` shorthand is deprecated. Use \`{ trigger: 'onNuxtReady' }\` instead.`)
+      warn?.(`[nuxt-scripts] registry.${key}: \`true\` shorthand is deprecated. Use \`{ trigger: 'onNuxtReady' }\` instead.`)
       registry[key] = [{}, { trigger: 'onNuxtReady' }] satisfies NormalizedRegistryEntry
       continue
     }

--- a/packages/script/src/normalize.ts
+++ b/packages/script/src/normalize.ts
@@ -24,6 +24,49 @@ export function extractRequiredFields(schema: RegistryScript['schema']): string[
 }
 
 /**
+ * Rewrite deprecated config keys in-place before normalization.
+ * Currently handles: `reverseProxyIntercept` → `proxy`.
+ */
+export function migrateDeprecatedRegistryKeys(
+  registry: Record<string, unknown>,
+  warn: (msg: string) => void,
+): void {
+  for (const key of Object.keys(registry)) {
+    const entry = registry[key]
+    if (!entry || typeof entry !== 'object')
+      continue
+
+    if (Array.isArray(entry)) {
+      // Array tuple: check scriptOptions (second element)
+      const opts = entry[1]
+      if (opts && typeof opts === 'object' && 'reverseProxyIntercept' in opts) {
+        warn(`registry.${key}: \`reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
+        const o = opts as Record<string, unknown>
+        o.proxy ??= o.reverseProxyIntercept
+        delete o.reverseProxyIntercept
+      }
+    }
+    else {
+      const obj = entry as Record<string, unknown>
+      // Top-level key
+      if ('reverseProxyIntercept' in obj) {
+        warn(`registry.${key}: \`reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
+        obj.proxy ??= obj.reverseProxyIntercept
+        delete obj.reverseProxyIntercept
+      }
+      // Nested scriptOptions
+      const so = obj.scriptOptions
+      if (so && typeof so === 'object' && 'reverseProxyIntercept' in so) {
+        warn(`registry.${key}: \`scriptOptions.reverseProxyIntercept\` has been renamed to \`proxy\`. Please update your config. Auto-migrating for now.`)
+        const s = so as Record<string, unknown>
+        s.proxy ??= s.reverseProxyIntercept
+        delete s.reverseProxyIntercept
+      }
+    }
+  }
+}
+
+/**
  * Normalize all registry config entries in-place to [input, scriptOptions?] tuple form.
  *
  * User-facing config shapes:

--- a/packages/script/src/normalize.ts
+++ b/packages/script/src/normalize.ts
@@ -4,7 +4,7 @@ import type { NuxtUseScriptOptionsSerializable, RegistryScript } from './runtime
 export type NormalizedRegistryEntry = [input: Record<string, unknown>, scriptOptions?: NormalizedScriptOptions]
 
 export type NormalizedScriptOptions = Partial<Omit<NuxtUseScriptOptionsSerializable, 'trigger'>> & {
-  trigger?: NuxtUseScriptOptionsSerializable['trigger'] | 'manual'
+  trigger?: NuxtUseScriptOptionsSerializable['trigger'] | 'manual' | false
   skipValidation?: boolean
 }
 
@@ -78,10 +78,13 @@ export function migrateDeprecatedRegistryKeys(
  * - `[input, scriptOptions]` → unchanged (internal/backwards compat)
  *
  * Aliases:
- * - `true` → `[{}, { trigger: 'onNuxtReady' }]` (auto-load globally)
+ * - `true` → `[{}, { trigger: 'onNuxtReady' }]` (deprecated, use `{ trigger: 'onNuxtReady' }`)
  * - `'proxy-only'` → build error with migration message
  */
-export function normalizeRegistryConfig(registry: Record<string, unknown>): void {
+export function normalizeRegistryConfig(
+  registry: Record<string, unknown>,
+  warn?: (msg: string) => void,
+): void {
   for (const key of Object.keys(registry)) {
     const entry = registry[key]
     if (!entry) {
@@ -89,6 +92,7 @@ export function normalizeRegistryConfig(registry: Record<string, unknown>): void
       continue
     }
     if (entry === true) {
+      warn?.(`registry.${key}: \`true\` shorthand is deprecated. Use \`{ trigger: 'onNuxtReady' }\` instead.`)
       registry[key] = [{}, { trigger: 'onNuxtReady' }] satisfies NormalizedRegistryEntry
       continue
     }

--- a/packages/script/src/runtime/types.ts
+++ b/packages/script/src/runtime/types.ts
@@ -251,7 +251,7 @@ export type RegistryScriptKey = Exclude<keyof ScriptRegistry, `${string}-npm`>
 
 type RegistryConfigInput<T> = [T] extends [true] ? Record<string, never> : T
 
-export type NuxtConfigScriptRegistryEntry<T> = true | false | 'mock' | (RegistryConfigInput<T> & { trigger?: NuxtUseScriptOptionsSerializable['trigger'], proxy?: boolean, bundle?: boolean, partytown?: boolean, privacy?: ProxyPrivacyInput })
+export type NuxtConfigScriptRegistryEntry<T> = true | false | 'mock' | (RegistryConfigInput<T> & { trigger?: NuxtUseScriptOptionsSerializable['trigger'] | false, proxy?: boolean, bundle?: boolean, partytown?: boolean, privacy?: ProxyPrivacyInput })
 export type NuxtConfigScriptRegistry<T extends keyof ScriptRegistry = keyof ScriptRegistry> = Partial<{
   [key in T]: NuxtConfigScriptRegistryEntry<ScriptRegistry[key]>
 }> & Record<string & {}, NuxtConfigScriptRegistryEntry<any>>

--- a/test/unit/normalize.test.ts
+++ b/test/unit/normalize.test.ts
@@ -8,6 +8,15 @@ describe('normalizeRegistryConfig', () => {
     expect(registry.plausible).toEqual([{}, { trigger: 'onNuxtReady' }])
   })
 
+  it('warns when true shorthand is used', () => {
+    const warn = vi.fn()
+    const registry: Record<string, any> = { plausible: true }
+    normalizeRegistryConfig(registry, warn)
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toContain('true')
+    expect(warn.mock.calls[0][0]).toContain('deprecated')
+  })
+
   it('throws on "proxy-only" with migration message', () => {
     const registry: Record<string, any> = { ga: 'proxy-only' }
     expect(() => normalizeRegistryConfig(registry)).toThrowError(/proxy-only.*no longer supported/)
@@ -35,6 +44,12 @@ describe('normalizeRegistryConfig', () => {
     const registry: Record<string, any> = { ga: { id: 'G-xxx', trigger: 'onNuxtReady' } }
     normalizeRegistryConfig(registry)
     expect(registry.ga).toEqual([{ id: 'G-xxx' }, { trigger: 'onNuxtReady' }])
+  })
+
+  it('hoists trigger: false to scriptOptions', () => {
+    const registry: Record<string, any> = { ga: { id: 'G-xxx', trigger: false } }
+    normalizeRegistryConfig(registry)
+    expect(registry.ga).toEqual([{ id: 'G-xxx' }, { trigger: false }])
   })
 
   it('hoists proxy to scriptOptions', () => {

--- a/test/unit/normalize.test.ts
+++ b/test/unit/normalize.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { normalizeRegistryConfig } from '../../packages/script/src/normalize'
+import { describe, expect, it, vi } from 'vitest'
+import { migrateDeprecatedRegistryKeys, normalizeRegistryConfig } from '../../packages/script/src/normalize'
 
 describe('normalizeRegistryConfig', () => {
   it('normalizes true to [{}, { trigger: "onNuxtReady" }]', () => {
@@ -106,5 +106,55 @@ describe('normalizeRegistryConfig', () => {
     expect(registry.ga).toEqual([{ id: 'G-XXX' }])
     expect(registry.posthog).toEqual([{}, { trigger: 'manual', skipValidation: true }])
     expect(registry.stripe).toBeUndefined()
+  })
+})
+
+describe('migrateDeprecatedRegistryKeys', () => {
+  it('rewrites reverseProxyIntercept in flat object to proxy', () => {
+    const warn = vi.fn()
+    const registry: Record<string, any> = { ga: { id: 'G-xxx', reverseProxyIntercept: false } }
+    migrateDeprecatedRegistryKeys(registry, warn)
+    expect(registry.ga).toEqual({ id: 'G-xxx', proxy: false })
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toContain('reverseProxyIntercept')
+  })
+
+  it('rewrites reverseProxyIntercept in nested scriptOptions', () => {
+    const warn = vi.fn()
+    const registry: Record<string, any> = { ga: { id: 'G-xxx', scriptOptions: { reverseProxyIntercept: false } } }
+    migrateDeprecatedRegistryKeys(registry, warn)
+    expect(registry.ga.scriptOptions).toEqual({ proxy: false })
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('rewrites reverseProxyIntercept in array tuple scriptOptions', () => {
+    const warn = vi.fn()
+    const registry: Record<string, any> = { ga: [{ id: 'G-xxx' }, { reverseProxyIntercept: false }] }
+    migrateDeprecatedRegistryKeys(registry, warn)
+    expect(registry.ga[1]).toEqual({ proxy: false })
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('does not clobber existing proxy when both are present', () => {
+    const warn = vi.fn()
+    const registry: Record<string, any> = { ga: { id: 'G-xxx', proxy: true, reverseProxyIntercept: false } }
+    migrateDeprecatedRegistryKeys(registry, warn)
+    expect(registry.ga).toEqual({ id: 'G-xxx', proxy: true })
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('does not warn when reverseProxyIntercept is absent', () => {
+    const warn = vi.fn()
+    const registry: Record<string, any> = { ga: { id: 'G-xxx', proxy: false } }
+    migrateDeprecatedRegistryKeys(registry, warn)
+    expect(registry.ga).toEqual({ id: 'G-xxx', proxy: false })
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('skips non-object entries', () => {
+    const warn = vi.fn()
+    const registry: Record<string, any> = { ga: true, posthog: 'mock', stripe: false }
+    migrateDeprecatedRegistryKeys(registry, warn)
+    expect(warn).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Related to #594

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

v0 users upgrading to v1 hit silent failures when using renamed or removed config keys. This PR adds build time detection and auto migration for `reverseProxyIntercept` → `proxy`, warns on missing triggers, and documents the changes in the migration guide.

**Config migration (`normalize.ts`, `module.ts`):**
- New `migrateDeprecatedRegistryKeys()` runs before normalization, detecting `reverseProxyIntercept` in flat objects, nested `scriptOptions`, and array tuples. Auto rewrites to `proxy` (without clobbering existing values) and emits a `[nuxt-scripts]` prefixed warning.
- `true` shorthand emits a deprecation warning pointing to `{ trigger: 'onNuxtReady' }`
- Missing trigger warning fires when user-provided input fields exist without an explicit `trigger`, filtering out env-var-only defaults to avoid false positives
- `trigger: false` supported as explicit infrastructure-only opt-out (proxy routes, types, bundling registered; no `<script>` tag injected)
- 6 unit tests for `migrateDeprecatedRegistryKeys`, additional tests for `true` deprecation and `trigger: false`

**Docs updates:**
- `true` replaced with `{ trigger: 'onNuxtReady' }` across all registry script docs
- Migration guide expanded with "Scripts No Longer Auto-Load" section, before/after examples, and condensed config migration table
- `trigger: false` clarified: registers infrastructure only, useful when loading via component/composable

**Migration guide (`v0-to-v1.md`):**
- Added `reverseProxyIntercept` → `proxy` rename documentation
- Added Google Maps component consolidation section (AdvancedMarkerElement → Marker rename, PinElement removal, markers/centerMarker prop removal)