### PR TITLE
fix(types): broken IDE display of registry types

### DIFF
--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -119,7 +119,7 @@ export function isProxyDisabled(
   registry?: NuxtConfigScriptRegistry,
   runtimeConfig?: Record<string, any>,
 ): boolean {
-  const entry = registry?.[registryKey as keyof NuxtConfigScriptRegistry] as NormalizedRegistryEntry | undefined
+  const entry = registry?.[registryKey] as NormalizedRegistryEntry | undefined
   if (!entry)
     return true
   const [input, scriptOptions] = entry
@@ -143,7 +143,7 @@ export function applyAutoInject(
   if (isProxyDisabled(registryKey, registry, runtimeConfig))
     return
 
-  const entry = registry[registryKey as keyof NuxtConfigScriptRegistry] as NormalizedRegistryEntry
+  const entry = registry[registryKey] as NormalizedRegistryEntry
   const input = entry[0]
 
   const rtScripts = runtimeConfig.public?.scripts as Record<string, any> | undefined

--- a/packages/script/src/runtime/types.ts
+++ b/packages/script/src/runtime/types.ts
@@ -252,9 +252,25 @@ export type RegistryScriptKey = Exclude<keyof ScriptRegistry, `${string}-npm`>
 type RegistryConfigInput<T> = [T] extends [true] ? Record<string, never> : T
 
 export type NuxtConfigScriptRegistryEntry<T> = true | false | 'mock' | (RegistryConfigInput<T> & { trigger?: NuxtUseScriptOptionsSerializable['trigger'] | false, proxy?: boolean, bundle?: boolean, partytown?: boolean, privacy?: ProxyPrivacyInput })
-export type NuxtConfigScriptRegistry<T extends keyof ScriptRegistry = keyof ScriptRegistry> = Partial<{
-  [key in T]: NuxtConfigScriptRegistryEntry<ScriptRegistry[key]>
-}> & Record<string & {}, NuxtConfigScriptRegistryEntry<any>>
+
+// Internal mapped type: derives config entry types from ScriptRegistry.
+// Excludes the `${string}-npm` pattern since it's covered by the string index signature.
+type _NuxtConfigScriptRegistryEntries = {
+  [K in keyof ScriptRegistry as K extends `${string}-npm` ? never : K]?: NuxtConfigScriptRegistryEntry<ScriptRegistry[K]>
+}
+
+// Interface (not intersection) ensures IDE displays specific types for known keys.
+// Explicit properties inherited via `extends` always take priority over the index
+// signature, making this immune to catch-all type contamination.
+// Augmenting ScriptRegistry automatically flows through to this type.
+//
+// The index signature uses `any` to satisfy TypeScript's constraint that all
+// inherited properties must be subtypes of the index type. This is safe because
+// in an interface, explicit properties always take priority over the index
+// signature for property access.
+export interface NuxtConfigScriptRegistry extends _NuxtConfigScriptRegistryEntries {
+  [key: string]: any
+}
 
 export type UseFunctionType<T, U> = T extends {
   use: infer V

--- a/packages/script/src/templates.ts
+++ b/packages/script/src/templates.ts
@@ -115,14 +115,15 @@ export function templatePlugin(config: Partial<ModuleOptions>, registry: Require
   for (const [k, c] of Object.entries(config.registry || {})) {
     if (c === false)
       continue
-    const [, scriptOptions] = c as [Record<string, any>, any?]
+    const entry = c as unknown as [Record<string, any>, any?]
+    const [, scriptOptions] = entry
     if (!scriptOptions?.trigger)
       continue
     const importDefinition = registry.find(i => i.import.name.toLowerCase() === `usescript${k.toLowerCase()}`)
     if (importDefinition) {
       resolvedRegistryKeys.push(k)
       imports.unshift(`import { ${importDefinition.import.name} } from '${importDefinition.import.from}'`)
-      const [input] = c as [Record<string, any>, any?]
+      const [input] = entry
       const opts = { ...scriptOptions }
       const triggerResolved = resolveTriggerForTemplate(opts.trigger)
       if (triggerResolved) {

--- a/test/types/types.test-d.ts
+++ b/test/types/types.test-d.ts
@@ -2,6 +2,7 @@ import type { ModuleOptions } from '../../packages/script/src/module'
 import type { CrispApi } from '../../packages/script/src/runtime/registry/crisp'
 import type { DefaultEventName } from '../../packages/script/src/runtime/registry/google-analytics'
 import type {
+  NuxtConfigScriptRegistry,
   NuxtUseScriptOptions,
   RegistryScriptInput,
   ScriptRegistry,
@@ -10,14 +11,72 @@ import type {
 import { describe, expectTypeOf, it } from 'vitest'
 
 describe('module options registry', () => {
-  it('registry entries are typed', () => {
-    // Check specific registry keys have proper types (not any)
-    // Using specific keys because the index signature `[key: \`${string}-npm\`]`
-    // causes `keyof ScriptRegistry` to include template literals which resolve to any
-    type Registry = NonNullable<ModuleOptions['registry']>
-    expectTypeOf<Registry['googleAnalytics']>().not.toBeAny()
+  type Registry = NonNullable<ModuleOptions['registry']>
+
+  it('all registry entries are typed, not any', () => {
+    // Every built-in registry key must resolve to its specific type, not `any`.
+    // NuxtConfigScriptRegistry is an interface (not an intersection), so explicit
+    // properties inherited via `extends` always take priority over the index signature.
+    expectTypeOf<Registry['bingUet']>().not.toBeAny()
+    expectTypeOf<Registry['blueskyEmbed']>().not.toBeAny()
+    expectTypeOf<Registry['carbonAds']>().not.toBeAny()
+    expectTypeOf<Registry['crisp']>().not.toBeAny()
     expectTypeOf<Registry['clarity']>().not.toBeAny()
+    expectTypeOf<Registry['cloudflareWebAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['databuddyAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['metaPixel']>().not.toBeAny()
+    expectTypeOf<Registry['fathomAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['instagramEmbed']>().not.toBeAny()
+    expectTypeOf<Registry['plausibleAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['googleAdsense']>().not.toBeAny()
+    expectTypeOf<Registry['googleAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['googleMaps']>().not.toBeAny()
+    expectTypeOf<Registry['googleRecaptcha']>().not.toBeAny()
+    expectTypeOf<Registry['googleSignIn']>().not.toBeAny()
+    expectTypeOf<Registry['lemonSqueezy']>().not.toBeAny()
+    expectTypeOf<Registry['googleTagManager']>().not.toBeAny()
+    expectTypeOf<Registry['hotjar']>().not.toBeAny()
+    expectTypeOf<Registry['intercom']>().not.toBeAny()
+    expectTypeOf<Registry['paypal']>().not.toBeAny()
+    expectTypeOf<Registry['posthog']>().not.toBeAny()
+    expectTypeOf<Registry['matomoAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['mixpanelAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['rybbitAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['redditPixel']>().not.toBeAny()
+    expectTypeOf<Registry['segment']>().not.toBeAny()
     expectTypeOf<Registry['stripe']>().not.toBeAny()
+    expectTypeOf<Registry['tiktokPixel']>().not.toBeAny()
+    expectTypeOf<Registry['xEmbed']>().not.toBeAny()
+    expectTypeOf<Registry['xPixel']>().not.toBeAny()
+    expectTypeOf<Registry['snapchatPixel']>().not.toBeAny()
+    expectTypeOf<Registry['youtubePlayer']>().not.toBeAny()
+    expectTypeOf<Registry['vercelAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['vimeoPlayer']>().not.toBeAny()
+    expectTypeOf<Registry['umamiAnalytics']>().not.toBeAny()
+    expectTypeOf<Registry['gravatar']>().not.toBeAny()
+    expectTypeOf<Registry['npm']>().not.toBeAny()
+  })
+
+  it('known keys resolve to their exact entry type, not the catch-all', () => {
+    // Known registry keys must resolve to NuxtConfigScriptRegistryEntry<SpecificInput>,
+    // not the index signature's NuxtConfigScriptRegistryEntry<Record<string, unknown>>.
+    // The interface approach guarantees this: inherited properties from `extends` always
+    // take priority over the index signature.
+    type GoogleMapsEntry = NuxtConfigScriptRegistry['googleMaps']
+    type CatchAllEntry = NuxtConfigScriptRegistry[string]
+    // Known key must NOT equal the catch-all
+    expectTypeOf<GoogleMapsEntry>().not.toEqualTypeOf<CatchAllEntry>()
+
+    // Verify specific input properties survive (not collapsed to unknown)
+    type ObjectForm<K extends keyof Registry> = Exclude<Registry[K], boolean | 'mock' | undefined>
+    expectTypeOf<ObjectForm<'googleMaps'>['apiKey']>().not.toBeNever()
+    expectTypeOf<ObjectForm<'googleAnalytics'>['id']>().not.toBeNever()
+    expectTypeOf<ObjectForm<'clarity'>['id']>().not.toBeNever()
+  })
+
+  it('registry allows unknown keys as catch-all', () => {
+    // Unknown keys fall through to the index signature (any), so custom scripts work
+    expectTypeOf<Registry['my-custom-script']>().toBeAny()
   })
 })
 

--- a/test/types/types.test-d.ts
+++ b/test/types/types.test-d.ts
@@ -59,7 +59,7 @@ describe('module options registry', () => {
 
   it('known keys resolve to their exact entry type, not the catch-all', () => {
     // Known registry keys must resolve to NuxtConfigScriptRegistryEntry<SpecificInput>,
-    // not the index signature's NuxtConfigScriptRegistryEntry<Record<string, unknown>>.
+    // not the index signature's `any` catch-all.
     // The interface approach guarantees this: inherited properties from `extends` always
     // take priority over the index signature.
     type GoogleMapsEntry = NuxtConfigScriptRegistry['googleMaps']


### PR DESCRIPTION
### 🔗 Linked issue

Related to #594

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`NuxtConfigScriptRegistry` used a type intersection (mapped type `&` index signature with `NuxtConfigScriptRegistryEntry<any>`) which caused IDEs to display known registry keys like `googleMaps` as `NuxtConfigScriptRegistryEntry<any>`, losing autocomplete for script-specific properties like `apiKey`.

Replaced with an **interface that extends the mapped type**. In an interface, explicit properties inherited via `extends` always take priority over the index signature for property access. This makes it structurally immune to catch-all type contamination. `ScriptRegistry` augmentations flow through automatically since the mapped type derives from `keyof ScriptRegistry`.

Also adds comprehensive type tests covering all 38 registry keys with `not.toBeAny()` assertions, structural property checks (`apiKey`, `id` not `never`), and a `not.toEqualTypeOf` guard ensuring known keys differ from the catch-all.