### PR TITLE
fix(types): prevent registry entry types from collapsing to `never`

### DIFF
--- a/packages/script/src/runtime/types.ts
+++ b/packages/script/src/runtime/types.ts
@@ -253,7 +253,7 @@ export type BuiltInRegistryScriptKey
  */
 export type RegistryScriptKey = Exclude<keyof ScriptRegistry, `${string}-npm`>
 
-type RegistryConfigInput<T> = [T] extends [true] ? Record<string, never> : T
+type RegistryConfigInput<T> = 0 extends 1 & T ? Record<string, any> : [T] extends [true] ? Record<string, never> : T
 
 export type NuxtConfigScriptRegistryEntry<T> = true | false | 'mock' | (RegistryConfigInput<T> & { trigger?: NuxtUseScriptOptionsSerializable['trigger'] | false, proxy?: boolean, bundle?: boolean, partytown?: boolean, privacy?: ProxyPrivacyInput })
 

--- a/test/types/types.test-d.ts
+++ b/test/types/types.test-d.ts
@@ -1,13 +1,7 @@
 import type { ModuleOptions } from '../../packages/script/src/module'
 import type { CrispApi } from '../../packages/script/src/runtime/registry/crisp'
 import type { DefaultEventName } from '../../packages/script/src/runtime/registry/google-analytics'
-import type {
-  NuxtConfigScriptRegistry,
-  NuxtUseScriptOptions,
-  RegistryScriptInput,
-  ScriptRegistry,
-  UseScriptContext,
-} from '../../packages/script/src/runtime/types'
+import type { NuxtConfigScriptRegistry, NuxtConfigScriptRegistryEntry, NuxtUseScriptOptions, RegistryScriptInput, ScriptRegistry, UseScriptContext } from '../../packages/script/src/runtime/types'
 import { describe, expectTypeOf, it } from 'vitest'
 
 describe('module options registry', () => {
@@ -77,6 +71,17 @@ describe('module options registry', () => {
   it('registry allows unknown keys as catch-all', () => {
     // Unknown keys fall through to the index signature (any), so custom scripts work
     expectTypeOf<Registry['my-custom-script']>().toBeAny()
+  })
+
+  // Issue #700: NuxtConfigScriptRegistryEntry<any> must not collapse to Record<string, never>
+  // This happens when Nuxt's $production/$development wraps the config in DeepPartial,
+  // collapsing the interface's index signature priority and resolving all keys to `any`.
+  it('NuxtConfigScriptRegistryEntry<any> allows arbitrary properties', () => {
+    type Entry = Exclude<NuxtConfigScriptRegistryEntry<any>, boolean | 'mock'>
+    // Must not be never (would mean Record<string, never> killed the intersection)
+    expectTypeOf<Entry>().not.toBeNever()
+    // Arbitrary properties must be assignable, not `never`
+    expectTypeOf<{ matomoUrl: string, siteId: number }>().toMatchTypeOf<Entry>()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #700

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`RegistryConfigInput<T>` uses `[T] extends [true]` to detect scripts with no options. However, `[any] extends [true]` also evaluates to `true` in TypeScript, which causes all script-specific properties to become `never`.

This triggers when Nuxt's `$production`/`$development` environment overrides apply a `DeepPartial` transformation that collapses the `NuxtConfigScriptRegistry` interface into a plain mapped type, losing interface property priority over the `[key: string]: any` index signature. All registry keys then resolve to `any`, and `RegistryConfigInput<any>` produces `Record<string, never>`.

Fixed by adding `any` detection (`0 extends 1 & T`) before the `true` check, so `any` resolves to `Record<string, any>` instead. Added a type test covering this case.