### PR TITLE
fix: avoid mutating runtimeConfig when merging registry script options

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -41,7 +41,7 @@ export function scriptRuntimeConfig<T extends keyof ScriptRegistry>(key: T) {
 
 export function useRegistryScript<T extends Record<string | symbol, any>, O = EmptyOptionsSchema>(registryKey: keyof ScriptRegistry | string, optionsFn: OptionsFn<O>, _userOptions?: RegistryScriptInput<O>): UseScriptContext<UseFunctionType<NuxtUseScriptOptions<T>, T>> {
   const scriptConfig = scriptRuntimeConfig(registryKey as keyof ScriptRegistry)
-  const userOptions = Object.assign(_userOptions || {}, typeof scriptConfig === 'object' ? scriptConfig : {})
+  const userOptions = defu(_userOptions || {}, typeof scriptConfig === 'object' ? scriptConfig : {})
   const options = optionsFn(userOptions as InferIfSchema<O>, { scriptInput: userOptions.scriptInput as UseScriptInput & { src?: string } })
 
   let finalScriptInput = options.scriptInput
@@ -70,7 +70,7 @@ export function useRegistryScript<T extends Record<string | symbol, any>, O = Em
   }
 
   const scriptInput = defu(finalScriptInput, userOptions.scriptInput, { key: registryKey }) as any as UseScriptInput
-  const scriptOptions = Object.assign(userOptions?.scriptOptions || {}, options.scriptOptions || {})
+  const scriptOptions = { ...userOptions?.scriptOptions, ...options.scriptOptions }
   if (import.meta.dev) {
     // Capture where the component was loaded from
     const error = new Error('Stack trace for component location')

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -126,3 +126,29 @@ describe('useRegistryScript query param merging', () => {
     expect(result.input.src).toBe('https://custom-domain.com/custom/path/script.js?version=2&custom=true&id=123')
   })
 })
+
+describe('useRegistryScript runtimeConfig isolation', () => {
+  it('should not mutate runtimeConfig.public.scripts when merging registry-defined scriptOptions', async () => {
+    const runtimeScriptConfig = {
+      token: 'abc',
+      scriptOptions: { trigger: 'client' as const },
+    }
+    vi.resetModules()
+    vi.doMock('nuxt/app', () => ({
+      useRuntimeConfig: () => ({ public: { scripts: { regTest: runtimeScriptConfig } } }),
+    }))
+    const { useRegistryScript: useRegistryScriptFresh } = await import('../../src/runtime/utils')
+
+    useRegistryScriptFresh('regTest', () => ({
+      scriptInput: { src: 'https://example.com/s.js' },
+      scriptOptions: {
+        use: () => ({ api: 'x' }),
+      } as any,
+    }))
+
+    // runtimeConfig entry should remain free of function properties.
+    expect(typeof (runtimeScriptConfig.scriptOptions as any).use).toBe('undefined')
+    expect(typeof (runtimeScriptConfig.scriptOptions as any).beforeInit).toBe('undefined')
+    expect(runtimeScriptConfig.scriptOptions.trigger).toBe('client')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #702 — `Cannot stringify a function` during prerender when a script is configured in `scripts.registry` in `nuxt.config`.

### Root cause

`useRegistryScript` in `src/runtime/utils.ts` used `Object.assign` to merge the registry-defined `scriptOptions` (which include the composable's `use()` function) into `userOptions.scriptOptions`. When the user configured the script via `nuxt.config`, `userOptions.scriptOptions` was a live reference to `runtimeConfig.public.scripts.<key>.scriptOptions`. The merge therefore wrote a function reference directly into `runtimeConfig`. The wrapped `beforeInit` function was then assigned to the same reference.

At prerender time, Nuxt's `renderPayloadJsonScript` calls `uneval(ssrContext.config)` which walks the public runtime config; devalue throws when it encounters the `use` / `beforeInit` functions that leaked in.

### Fix

Switch the two merges to `defu` / spread so they produce fresh objects and leave `runtimeConfig` untouched. This matches the v1 behavior (already fixed there).

## Test plan

- [x] Added a regression test in `test/unit/utils.test.ts` that asserts the runtime config object passed via `useRuntimeConfig().public.scripts.<key>` is not mutated by `useRegistryScript`. The test fails on current 0.x and passes with this fix.
- [x] All existing unit tests still pass (`pnpm test:unit`).
- [x] Manually verified `cloudflareWebAnalytics` with `scriptOptions: { trigger: 'client' }` in `scripts.registry` now prerenders cleanly.