### PR TITLE
fix(vercel-analytics): sink insight POSTs in dev to avoid 404s

### DIFF
--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -527,6 +527,16 @@ export default defineNuxtModule<ModuleOptions>({
     const proxyHandlerPath = await resolvePath('./runtime/server/proxy-handler')
     addServerHandler({ route: `${proxyPrefix}/**`, handler: proxyHandlerPath })
 
+    // In dev, sink Vercel Analytics insight POSTs to `/_vercel/insights/*` so
+    // they don't 404. Vercel's edge serves this path in production; locally
+    // there's no upstream, so we return 204 to keep the script happy.
+    if (nuxt.options.dev && config.registry?.vercelAnalytics) {
+      addServerHandler({
+        route: '/_vercel/insights/**',
+        handler: await resolvePath('./runtime/server/vercel-insights-sink'),
+      })
+    }
+
     const composables = [
       'useScript',
       'useScriptEventPage',

--- a/packages/script/src/runtime/server/vercel-insights-sink.ts
+++ b/packages/script/src/runtime/server/vercel-insights-sink.ts
@@ -1,0 +1,6 @@
+import { defineEventHandler, setResponseStatus } from 'h3'
+
+export default defineEventHandler((event) => {
+  setResponseStatus(event, 204)
+  return null
+})


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Vercel Analytics collects via a relative `/_vercel/insights/*` endpoint served by Vercel's edge. Outside Vercel (including `nuxt dev`) there is no upstream, so the bundled script POSTs to the local origin and 404s in devtools.

Register a dev-only server handler that returns 204 on `/_vercel/insights/**` when `vercelAnalytics` is enabled. Mirrors what Vercel's edge does in production as a local no-op, so the script loads normally and `track`/`pageview` work end-to-end in dev without noisy 404s.

Script behaviour, public options (`mode`, `debug`), and proxy domains are unchanged.