### PR TITLE
fix(google-maps): prevent blank space during page transitions

### DIFF
--- a/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
+++ b/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
@@ -479,9 +479,11 @@ onBeforeUnmount(() => {
   // so anything after an `await` runs as a detached microtask.
   // Note: do NOT null mapsApi here — children unmount AFTER onBeforeUnmount
   // and need mapsApi.value for clearInstanceListeners in their cleanup.
+  // Note: do NOT remove map DOM here — during page transitions the leave
+  // animation is still playing, and tearing out the iframe leaves blank
+  // space. Vue removes the parent element on actual unmount.
   map.value?.unbindAll()
   map.value = undefined
-  mapEl.value?.firstChild?.remove()
   libraries.clear()
   queryToLatLngCache.clear()
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #714

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`ScriptGoogleMaps` removed its map DOM (`mapEl.value?.firstChild?.remove()`) inside `onBeforeUnmount`, which fired while the page-transition leave animation was still playing and left a blank area where the map used to be. Vue already removes the parent element on actual unmount, so dropping the manual DOM removal lets the map stay visible through the transition.