### PR TITLE
fix(google-maps): handle marker + mapOptions.styles conflict

### DIFF
--- a/docs/content/scripts/google-maps/1.guides/2.map-styling.md
+++ b/docs/content/scripts/google-maps/1.guides/2.map-styling.md
@@ -2,13 +2,17 @@
 title: Map Styling
 ---
 
-Google Maps supports two styling approaches: legacy JSON styles and cloud-based map IDs. Both work with Nuxt Scripts, including the static map placeholder.
+Google Maps supports two styling approaches: legacy JSON styles and cloud-based map IDs. Cloud-based map IDs are the recommended approach for v1 and work with `ScriptGoogleMapsMarker`.
 
 ## JSON Styles
 
+::callout{color="amber"}
+JSON `styles` conflict with `ScriptGoogleMapsMarker` in v1. `AdvancedMarkerElement` requires a `mapId`, and Google Maps ignores `styles` when a `mapId` is present. If you need markers, use [cloud-based map IDs](#cloud-based-map-ids) instead.
+::
+
 Use the `mapOptions.styles` prop with a JSON style array. You can find pre-made styles on [Snazzy Maps](https://snazzymaps.com/).
 
-Styles automatically apply to both the static map placeholder and the interactive map.
+Styles apply to the static map placeholder and to the interactive map when the map has no markers.
 
 ```vue
 <script setup lang="ts">
@@ -63,7 +67,7 @@ Google's [Map Styling](https://developers.google.com/maps/documentation/cloud-cu
 ```
 
 ::callout{color="amber"}
-JSON `styles` and `mapId` are mutually exclusive. When you provide both, the component ignores `mapId` and applies `styles`. Note that `AdvancedMarkerElement` requires a map ID to function; legacy `Marker` works without one.
+JSON `styles` and `mapId` are mutually exclusive. When both are set, Google Maps keeps `mapId` and ignores `styles`. Because v1's `ScriptGoogleMapsMarker` uses `AdvancedMarkerElement` (which requires a `mapId`), cloud-based map IDs are the only way to style a map that contains markers.
 ::
 
 ## Dark Mode / Color Mode

--- a/docs/content/scripts/google-maps/1.guides/2.map-styling.md
+++ b/docs/content/scripts/google-maps/1.guides/2.map-styling.md
@@ -2,17 +2,17 @@
 title: Map Styling
 ---
 
-Google Maps supports two styling approaches: legacy JSON styles and cloud-based map IDs. Cloud-based map IDs are the recommended approach for v1 and work with `ScriptGoogleMapsMarker`.
+Google Maps supports two styling approaches: legacy JSON styles and cloud-based map IDs. Both work with Nuxt Scripts, including the static map placeholder.
 
 ## JSON Styles
 
-::callout{color="amber"}
-JSON `styles` conflict with `ScriptGoogleMapsMarker` in v1. `AdvancedMarkerElement` requires a `mapId`, and Google Maps ignores `styles` when a `mapId` is present. If you need markers, use [cloud-based map IDs](#cloud-based-map-ids) instead.
-::
-
 Use the `mapOptions.styles` prop with a JSON style array. You can find pre-made styles on [Snazzy Maps](https://snazzymaps.com/).
 
-Styles apply to the static map placeholder and to the interactive map when the map has no markers.
+Styles apply to both the static map placeholder and the interactive map.
+
+::callout{color="amber"}
+JSON `styles` cannot combine with `ScriptGoogleMapsMarker`. `AdvancedMarkerElement` requires a `mapId`, and Google Maps treats `styles` and `mapId` as mutually exclusive. If the map contains markers, use [cloud-based map IDs](#cloud-based-map-ids) instead.
+::
 
 ```vue
 <script setup lang="ts">
@@ -67,7 +67,7 @@ Google's [Map Styling](https://developers.google.com/maps/documentation/cloud-cu
 ```
 
 ::callout{color="amber"}
-JSON `styles` and `mapId` are mutually exclusive. When both are set, Google Maps keeps `mapId` and ignores `styles`. Because v1's `ScriptGoogleMapsMarker` uses `AdvancedMarkerElement` (which requires a `mapId`), cloud-based map IDs are the only way to style a map that contains markers.
+JSON `styles` and `mapId` are mutually exclusive. When both are set, Google Maps keeps `mapId` and ignores `styles`. Because `ScriptGoogleMapsMarker` uses `AdvancedMarkerElement` (which requires a `mapId`), cloud-based map IDs are the only way to style a map that contains markers.
 ::
 
 ## Dark Mode / Color Mode

--- a/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
+++ b/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
@@ -227,7 +227,7 @@ const options = computed(() => {
   // sets `styles`, we drop `mapId` so styles apply. Otherwise fall back to a map ID
   // so `AdvancedMarkerElement` can function. The marker component warns if markers
   // are mounted against a styled (mapId-less) map.
-  const mapId = props.mapOptions?.styles ? undefined : (currentMapId.value || 'map')
+  const mapId = props.mapOptions?.styles ? undefined : (currentMapId.value || 'DEMO_MAP_ID')
   return defu(
     { center: centerOverride.value, mapId },
     props.mapOptions,

--- a/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
+++ b/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
@@ -223,9 +223,11 @@ const { load, status, onLoaded } = useScriptGoogleMaps({
 })
 
 const options = computed(() => {
-  // v1 markers use AdvancedMarkerElement which requires a mapId, so we always pass one.
-  // Google will ignore JSON `styles` when `mapId` is set — we warn below in dev.
-  const mapId = currentMapId.value || 'map'
+  // JSON `styles` and `mapId` are mutually exclusive in Google Maps. When the user
+  // sets `styles`, we drop `mapId` so styles apply. Otherwise fall back to a map ID
+  // so `AdvancedMarkerElement` can function. The marker component warns if markers
+  // are mounted against a styled (mapId-less) map.
+  const mapId = props.mapOptions?.styles ? undefined : (currentMapId.value || 'map')
   return defu(
     { center: centerOverride.value, mapId },
     props.mapOptions,
@@ -233,14 +235,6 @@ const options = computed(() => {
     { zoom: 15 },
   )
 })
-
-if (import.meta.dev) {
-  watch(() => props.mapOptions?.styles, (styles) => {
-    if (styles) {
-      console.warn('[nuxt-scripts] <ScriptGoogleMaps> `mapOptions.styles` (JSON styles) is incompatible with `ScriptGoogleMapsMarker` in v1, which requires a `mapId` for `AdvancedMarkerElement`. Google Maps will ignore `styles` when `mapId` is set. Use cloud-based map styling instead: https://scripts.nuxt.com/scripts/google-maps/guides/map-styling')
-    }
-  }, { immediate: true })
-}
 const isMapReady = ref(false)
 
 const map: ShallowRef<google.maps.Map | undefined> = shallowRef()

--- a/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
+++ b/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMaps.vue
@@ -223,12 +223,9 @@ const { load, status, onLoaded } = useScriptGoogleMaps({
 })
 
 const options = computed(() => {
-  const mapId = props.mapOptions?.styles ? undefined : (currentMapId.value || 'map')
-  // Precedence (defu merges left-to-right, leftmost wins):
-  // 1. centerOverride: resolved query result, always wins for center
-  // 2. mapOptions: preferred public API
-  // 3. deprecated top-level: legacy fallback for center/zoom
-  // 4. defaults: { zoom: 15 } when nothing else is set
+  // v1 markers use AdvancedMarkerElement which requires a mapId, so we always pass one.
+  // Google will ignore JSON `styles` when `mapId` is set — we warn below in dev.
+  const mapId = currentMapId.value || 'map'
   return defu(
     { center: centerOverride.value, mapId },
     props.mapOptions,
@@ -236,6 +233,14 @@ const options = computed(() => {
     { zoom: 15 },
   )
 })
+
+if (import.meta.dev) {
+  watch(() => props.mapOptions?.styles, (styles) => {
+    if (styles) {
+      console.warn('[nuxt-scripts] <ScriptGoogleMaps> `mapOptions.styles` (JSON styles) is incompatible with `ScriptGoogleMapsMarker` in v1, which requires a `mapId` for `AdvancedMarkerElement`. Google Maps will ignore `styles` when `mapId` is set. Use cloud-based map styling instead: https://scripts.nuxt.com/scripts/google-maps/guides/map-styling')
+    }
+  }, { immediate: true })
+}
 const isMapReady = ref(false)
 
 const map: ShallowRef<google.maps.Map | undefined> = shallowRef()

--- a/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMapsMarker.vue
+++ b/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMapsMarker.vue
@@ -57,6 +57,9 @@ let gmpClickHandler: ((e: any) => void) | undefined
 const advancedMarkerElement = useGoogleMapsResource<google.maps.marker.AdvancedMarkerElement>({
   ready: () => !slots.content || !!markerContent.value,
   async create({ mapsApi, map }) {
+    if (import.meta.dev && !map.get('mapId')) {
+      console.warn('[nuxt-scripts] <ScriptGoogleMapsMarker> requires the parent <ScriptGoogleMaps> to have a `mapId` set, but none was found. This usually happens when `mapOptions.styles` (JSON styles) is set, since Google Maps treats `styles` and `mapId` as mutually exclusive. Use cloud-based map styling instead: https://scripts.nuxt.com/scripts/google-maps/guides/map-styling')
+    }
     await mapsApi.importLibrary('marker')
     const marker = new mapsApi.marker.AdvancedMarkerElement({
       ...props.options,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #716

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

v1 `ScriptGoogleMapsMarker` uses `AdvancedMarkerElement`, which requires a `mapId`. Google Maps treats JSON `styles` and `mapId` as mutually exclusive, so combining `mapOptions.styles` with a marker silently broke the map ("This Page Can't Load Google Maps Correctly.").

Google's API makes this genuinely unresolvable (styles need the raster renderer, advanced markers need the vector renderer). Rather than pick a side, this PR:

- Preserves the existing styles-only path in `ScriptGoogleMaps` (no regression for users with styled maps and no markers).
- Adds a dev-mode warning in `ScriptGoogleMapsMarker` when the parent map has no `mapId`, pointing users to cloud-based map styling.
- Changes the default `mapId` fallback from the arbitrary `'map'` to Google's pre-registered `'DEMO_MAP_ID'`, which silences the "initialized without a valid Map ID" warning Google logs for unregistered IDs.
- Updates the Map Styling guide to frame the conflict as JSON styles vs. markers (a Google constraint), not styles vs. the module.

No runtime behavior change for existing users; only new behavior is a dev-mode warning at the point the conflict actually surfaces.