### PR TITLE
fix(google-analytics): allow ga-audiences regional Google domains through proxy

### DIFF
--- a/packages/script/src/plugins/transform.ts
+++ b/packages/script/src/plugins/transform.ts
@@ -465,7 +465,10 @@ export function NuxtScriptBundleTransformer(options: AssetBundlerTransformerOpti
                       ? options.proxyConfigs?.[proxyConfigKey]
                       : undefined
                     // Derive rewrites from domains: { from: domain, to: proxyPrefix/domain }
-                    const proxyRewrites = proxyConfig?.domains?.map(domain => ({
+                    // Skip wildcard patterns — those exist only for runtime allowlist matching of
+                    // dynamically-constructed URLs (e.g. ga-audiences geo-localized cctlds) and have
+                    // no literal form to rewrite at build time.
+                    const proxyRewrites = proxyConfig?.domains?.filter(domain => !domain.includes('*')).map(domain => ({
                       from: domain,
                       to: `${options.proxyPrefix}/${domain}`,
                     }))

--- a/packages/script/src/registry.ts
+++ b/packages/script/src/registry.ts
@@ -734,7 +734,10 @@ export async function registry(resolve?: (path: string) => Promise<string>): Pro
         },
       },
       proxy: {
-        domains: ['www.google-analytics.com', 'analytics.google.com', 'stats.g.doubleclick.net', 'pagead2.googlesyndication.com', 'www.googleadservices.com', 'googleads.g.doubleclick.net', 'www.google.com', 'www.googletagmanager.com'],
+        // `www.google.com` covers static URLs (www.google.com/g/collect) rewritten at build time;
+        // `www.google.*` covers the geo-localized ga-audiences beacon, which gtag.js dynamically
+        // fires to the visitor's local Google cctld (www.google.com.tw, www.google.co.jp, ...).
+        domains: ['www.google-analytics.com', 'analytics.google.com', 'stats.g.doubleclick.net', 'pagead2.googlesyndication.com', 'www.googleadservices.com', 'googleads.g.doubleclick.net', 'www.google.com', 'www.google.*', 'www.googletagmanager.com'],
         privacy: PRIVACY_HEATMAP,
       },
       partytown: { forwards: ['dataLayer.push', 'gtag'] },

--- a/packages/script/src/runtime/server/proxy-handler.ts
+++ b/packages/script/src/runtime/server/proxy-handler.ts
@@ -1,6 +1,7 @@
 import type { ProxyPrivacyInput, ResolvedProxyPrivacy } from './utils/privacy'
 import { createError, defineEventHandler, getHeaders, getQuery, getRequestIP, getRequestWebStream, readBody, setResponseHeader, setResponseStatus } from 'h3'
 import { useNitroApp, useRuntimeConfig } from 'nitropack/runtime'
+import { matchDomain } from './utils/match-domain'
 import {
   anonymizeIP,
   mergePrivacy,
@@ -83,10 +84,10 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Find privacy config by matching domain (exact or parent domain match)
+  // Find privacy config by matching domain (exact, parent domain, or wildcard pattern)
   let perScriptInput: ProxyPrivacyInput | undefined
   for (const [configDomain, privacyInput] of Object.entries(domainPrivacy)) {
-    if (domain === configDomain || domain.endsWith(`.${configDomain}`)) {
+    if (matchDomain(domain, configDomain)) {
       perScriptInput = privacyInput
       break
     }

--- a/packages/script/src/runtime/server/utils/match-domain.ts
+++ b/packages/script/src/runtime/server/utils/match-domain.ts
@@ -1,41 +1,35 @@
 /**
  * Match a hostname against an allowlist pattern.
- * Patterns may include `*` as a wildcard that matches one or more characters
- * (excluding `/`); e.g. `www.google.*` matches `www.google.com`,
- * `www.google.com.tw`, `www.google.co.jp`. Bare patterns also match
- * subdomains, e.g. `google.com` matches `mail.google.com`.
+ *
+ * Patterns may include `*` as a TLD wildcard that matches a top-level domain
+ * suffix shaped like a ccTLD: either a single 2-3 letter label (`com`, `tw`,
+ * `jp`, `de`) or two such labels separated by a dot (`co.jp`, `com.tw`,
+ * `com.hk`). Used for geo-localized Google ccTLDs:
+ *   `www.google.*` matches `www.google.com`, `www.google.com.tw`, `www.google.co.jp`.
+ *
+ * Crucially, the wildcard does NOT match arbitrary attacker-controlled
+ * subdomains: `www.google.attacker.com` is rejected because `attacker` is
+ * longer than 3 characters (the cap that excludes generic SLDs like
+ * `attacker`, `evil-domain`, etc).
+ *
+ * Bare patterns also match subdomains, e.g. `google.com` matches `mail.google.com`.
  */
+const TLD_WILDCARD_RE = /^[a-z]{2,3}(?:\.[a-z]{2,3})?$/i
+
 export function matchDomain(domain: string, pattern: string): boolean {
   if (!pattern.includes('*'))
     return domain === pattern || domain.endsWith(`.${pattern}`)
 
-  // Walk literal segments split on `*`. This avoids constructing a regex from
-  // a free-form string (and the static-analysis warnings that follow). Each
-  // `*` requires at least one matched character that is not `/`.
-  if (domain.includes('/'))
+  // Only support a trailing single `*` wildcard for TLD matching (the only
+  // shape we use in practice). Reject any other pattern shape rather than
+  // silently allowing it.
+  if (!pattern.endsWith('*') || pattern.indexOf('*') !== pattern.length - 1)
     return false
-  const segments = pattern.split('*')
-  const lastIndex = segments.length - 1
-  let cursor = 0
-  for (let i = 0; i <= lastIndex; i++) {
-    const segment = segments[i] ?? ''
-    if (i === 0) {
-      if (!domain.startsWith(segment))
-        return false
-      cursor = segment.length
-      continue
-    }
-    if (i === lastIndex) {
-      if (!domain.endsWith(segment))
-        return false
-      const wildcardEnd = domain.length - segment.length
-      return wildcardEnd > cursor
-    }
-    const nextIdx = domain.indexOf(segment, cursor + 1)
-    if (nextIdx === -1)
-      return false
-    cursor = nextIdx + segment.length
-  }
-  // Lone `*` pattern: any non-empty domain (already excluded `/` above).
-  return domain.length > 0
+
+  const prefix = pattern.slice(0, -1) // includes trailing dot, e.g. "www.google."
+  if (!domain.startsWith(prefix))
+    return false
+
+  const tld = domain.slice(prefix.length)
+  return TLD_WILDCARD_RE.test(tld)
 }

--- a/packages/script/src/runtime/server/utils/match-domain.ts
+++ b/packages/script/src/runtime/server/utils/match-domain.ts
@@ -1,15 +1,41 @@
-const REGEX_ESCAPE_RE = /[.+?^${}()|[\]\\]/g
-
 /**
  * Match a hostname against an allowlist pattern.
- * Patterns may include `*` to match one or more non-dot characters; e.g. `www.google.*`
- * matches `www.google.com`, `www.google.com.tw`, `www.google.co.jp`. Bare patterns also
- * match subdomains, e.g. `google.com` matches `mail.google.com`.
+ * Patterns may include `*` as a wildcard that matches one or more characters
+ * (excluding `/`); e.g. `www.google.*` matches `www.google.com`,
+ * `www.google.com.tw`, `www.google.co.jp`. Bare patterns also match
+ * subdomains, e.g. `google.com` matches `mail.google.com`.
  */
 export function matchDomain(domain: string, pattern: string): boolean {
-  if (pattern.includes('*')) {
-    const re = new RegExp(`^${pattern.replace(REGEX_ESCAPE_RE, '\\$&').replace(/\*/g, '[^/]+')}$`)
-    return re.test(domain)
+  if (!pattern.includes('*'))
+    return domain === pattern || domain.endsWith(`.${pattern}`)
+
+  // Walk literal segments split on `*`. This avoids constructing a regex from
+  // a free-form string (and the static-analysis warnings that follow). Each
+  // `*` requires at least one matched character that is not `/`.
+  if (domain.includes('/'))
+    return false
+  const segments = pattern.split('*')
+  const lastIndex = segments.length - 1
+  let cursor = 0
+  for (let i = 0; i <= lastIndex; i++) {
+    const segment = segments[i] ?? ''
+    if (i === 0) {
+      if (!domain.startsWith(segment))
+        return false
+      cursor = segment.length
+      continue
+    }
+    if (i === lastIndex) {
+      if (!domain.endsWith(segment))
+        return false
+      const wildcardEnd = domain.length - segment.length
+      return wildcardEnd > cursor
+    }
+    const nextIdx = domain.indexOf(segment, cursor + 1)
+    if (nextIdx === -1)
+      return false
+    cursor = nextIdx + segment.length
   }
-  return domain === pattern || domain.endsWith(`.${pattern}`)
+  // Lone `*` pattern: any non-empty domain (already excluded `/` above).
+  return domain.length > 0
 }

--- a/packages/script/src/runtime/server/utils/match-domain.ts
+++ b/packages/script/src/runtime/server/utils/match-domain.ts
@@ -2,19 +2,21 @@
  * Match a hostname against an allowlist pattern.
  *
  * Patterns may include `*` as a TLD wildcard that matches a top-level domain
- * suffix shaped like a ccTLD: either a single 2-3 letter label (`com`, `tw`,
- * `jp`, `de`) or two such labels separated by a dot (`co.jp`, `com.tw`,
- * `com.hk`). Used for geo-localized Google ccTLDs:
+ * suffix shaped like a real ccTLD or gTLD:
+ *   - `com` (the canonical gTLD we care about)
+ *   - any 2-letter ccTLD (`tw`, `jp`, `de`, ...)
+ *   - regional `com.<cc>` or `co.<cc>` (e.g. `com.tw`, `co.jp`, `com.hk`)
+ *
+ * Used for geo-localized Google ccTLDs:
  *   `www.google.*` matches `www.google.com`, `www.google.com.tw`, `www.google.co.jp`.
  *
- * Crucially, the wildcard does NOT match arbitrary attacker-controlled
- * subdomains: `www.google.attacker.com` is rejected because `attacker` is
- * longer than 3 characters (the cap that excludes generic SLDs like
- * `attacker`, `evil-domain`, etc).
+ * The pattern is intentionally narrow: it rejects attacker-controlled suffixes
+ * like `www.google.foo.bar` (two arbitrary 3-letter labels) or
+ * `www.google.attacker.com` (long second-level label).
  *
  * Bare patterns also match subdomains, e.g. `google.com` matches `mail.google.com`.
  */
-const TLD_WILDCARD_RE = /^[a-z]{2,3}(?:\.[a-z]{2,3})?$/i
+const TLD_WILDCARD_RE = /^(?:com|[a-z]{2}|(?:com|co)\.[a-z]{2})$/i
 
 export function matchDomain(domain: string, pattern: string): boolean {
   if (!pattern.includes('*'))

--- a/packages/script/src/runtime/server/utils/match-domain.ts
+++ b/packages/script/src/runtime/server/utils/match-domain.ts
@@ -1,0 +1,15 @@
+const REGEX_ESCAPE_RE = /[.+?^${}()|[\]\\]/g
+
+/**
+ * Match a hostname against an allowlist pattern.
+ * Patterns may include `*` to match one or more non-dot characters; e.g. `www.google.*`
+ * matches `www.google.com`, `www.google.com.tw`, `www.google.co.jp`. Bare patterns also
+ * match subdomains, e.g. `google.com` matches `mail.google.com`.
+ */
+export function matchDomain(domain: string, pattern: string): boolean {
+  if (pattern.includes('*')) {
+    const re = new RegExp(`^${pattern.replace(REGEX_ESCAPE_RE, '\\$&').replace(/\*/g, '[^/]+')}$`)
+    return re.test(domain)
+  }
+  return domain === pattern || domain.endsWith(`.${pattern}`)
+}

--- a/test/unit/proxy-handler-match-domain.test.ts
+++ b/test/unit/proxy-handler-match-domain.test.ts
@@ -37,6 +37,9 @@ describe('matchDomain', () => {
     expect(matchDomain('www.google.evil-domain.com', 'www.google.*')).toBe(false)
     // Three or more labels in the suffix → not a valid ccTLD shape
     expect(matchDomain('www.google.a.b.c', 'www.google.*')).toBe(false)
+    // Two arbitrary 3-letter labels are not a real ccTLD shape; only com.<cc> / co.<cc> allowed
+    expect(matchDomain('www.google.foo.bar', 'www.google.*')).toBe(false)
+    expect(matchDomain('www.google.abc.xyz', 'www.google.*')).toBe(false)
   })
 
   it('escapes regex metachars in the pattern', () => {

--- a/test/unit/proxy-handler-match-domain.test.ts
+++ b/test/unit/proxy-handler-match-domain.test.ts
@@ -29,6 +29,16 @@ describe('matchDomain', () => {
     expect(matchDomain('www.googleX.com', 'www.google.*')).toBe(false)
   })
 
+  // Security: the wildcard must not match attacker-controlled subdomains.
+  // Without a TLD shape constraint, `*` would match `attacker.com` here.
+  it('wildcard rejects attacker-controlled suffixes', () => {
+    expect(matchDomain('www.google.attacker.com', 'www.google.*')).toBe(false)
+    expect(matchDomain('www.google.com.attacker.com', 'www.google.*')).toBe(false)
+    expect(matchDomain('www.google.evil-domain.com', 'www.google.*')).toBe(false)
+    // Three or more labels in the suffix → not a valid ccTLD shape
+    expect(matchDomain('www.google.a.b.c', 'www.google.*')).toBe(false)
+  })
+
   it('escapes regex metachars in the pattern', () => {
     expect(matchDomain('foo.bar.com', 'foo+bar.com')).toBe(false)
     expect(matchDomain('foo+bar.com', 'foo+bar.com')).toBe(true)

--- a/test/unit/proxy-handler-match-domain.test.ts
+++ b/test/unit/proxy-handler-match-domain.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { matchDomain } from '../../packages/script/src/runtime/server/utils/match-domain'
+
+describe('matchDomain', () => {
+  it('matches exact hostname', () => {
+    expect(matchDomain('www.google-analytics.com', 'www.google-analytics.com')).toBe(true)
+  })
+
+  it('matches subdomain via parent pattern', () => {
+    expect(matchDomain('mail.google.com', 'google.com')).toBe(true)
+    expect(matchDomain('google.com', 'google.com')).toBe(true)
+  })
+
+  it('rejects non-matching hostname', () => {
+    expect(matchDomain('evil.com', 'google.com')).toBe(false)
+    expect(matchDomain('googleX.com', 'google.com')).toBe(false)
+  })
+
+  // Issue #728: ga-audiences fires to www.google.<cctld> based on geo
+  it('matches geo-localized Google ccTLDs via wildcard', () => {
+    expect(matchDomain('www.google.com', 'www.google.*')).toBe(true)
+    expect(matchDomain('www.google.com.tw', 'www.google.*')).toBe(true)
+    expect(matchDomain('www.google.co.jp', 'www.google.*')).toBe(true)
+    expect(matchDomain('www.google.com.hk', 'www.google.*')).toBe(true)
+  })
+
+  it('wildcard does not match a different host root', () => {
+    expect(matchDomain('evil.google.com', 'www.google.*')).toBe(false)
+    expect(matchDomain('www.googleX.com', 'www.google.*')).toBe(false)
+  })
+
+  it('escapes regex metachars in the pattern', () => {
+    expect(matchDomain('foo.bar.com', 'foo+bar.com')).toBe(false)
+    expect(matchDomain('foo+bar.com', 'foo+bar.com')).toBe(true)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #728

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`gtag.js` fires `ga-audiences` beacons to the visitor's geo-localized Google ccTLD (`www.google.com.tw`, `www.google.co.jp`, `www.google.com.hk`, ...), but the proxy allowlist only listed `www.google.com`, so non-US visitors hit a 403 "Domain not allowed".

The fix adds `www.google.*` to the GA proxy domains and a small `matchDomain` helper that supports `*` wildcards for the runtime allowlist check. The build-time transform skips wildcard patterns since they have no literal form to rewrite at build time, leaving static URLs (e.g. `www.google.com/g/collect`) covered by the existing literal entry.