### PR TITLE
fix(assets): set js content-type on dev bundled asset handler

### DIFF
--- a/packages/script/src/assets.ts
+++ b/packages/script/src/assets.ts
@@ -1,6 +1,6 @@
 import type { NitroConfig } from 'nitropack'
 import { addDevServerHandler, extendRouteRules, tryUseNuxt, useNuxt } from '@nuxt/kit'
-import { createError, eventHandler, lazyEventHandler } from 'h3'
+import { createError, eventHandler, lazyEventHandler, setHeader } from 'h3'
 import { fetch } from 'ofetch'
 import { join, resolve } from 'pathe'
 import { joinURL } from 'ufo'
@@ -57,6 +57,8 @@ export function setupPublicAssetStrategy(assetsBaseURL: string) {
 
         if (!scriptDescriptor || scriptDescriptor instanceof Error)
           throw createError({ statusCode: 404 })
+
+        setHeader(event, 'content-type', 'application/javascript; charset=utf-8')
 
         // Use pre-rendered content which includes proxy rewrites for first-party mode
         if (scriptDescriptor.content) {


### PR DESCRIPTION
## Summary
- Dev handler at `packages/script/src/assets.ts` returned a `Buffer` without a `Content-Type` header, so Firefox rejected bundled scripts (`/_scripts/assets/<hash>.js`) with `MIME type ("") is not a valid JavaScript MIME type`.
- Set `application/javascript; charset=utf-8` explicitly before returning content.

Closes part of #746 (the dev-side MIME warning). The production `/_nuxt/*.js` being served as `application/json` reported in that issue is unrelated, that's a reverse-proxy/CDN misconfiguration on the user's side.

## Test plan
- [ ] Run a playground script with `bundle: true` in dev, confirm `/_scripts/assets/*.js` now responds with `content-type: application/javascript; charset=utf-8`.
- [ ] Verify Firefox no longer logs the MIME warning.