### PR TITLE
fix(proxy): allow `region1.google-analytics.com`

### DIFF
--- a/packages/script/src/registry.ts
+++ b/packages/script/src/registry.ts
@@ -764,7 +764,7 @@ export async function registry(resolve?: (path: string) => Promise<string>): Pro
         // `www.google.com` covers static URLs (www.google.com/g/collect) rewritten at build time;
         // `www.google.*` covers the geo-localized ga-audiences beacon, which gtag.js dynamically
         // fires to the visitor's local Google cctld (www.google.com.tw, www.google.co.jp, ...).
-        domains: ['www.google-analytics.com', 'analytics.google.com', 'stats.g.doubleclick.net', 'pagead2.googlesyndication.com', 'www.googleadservices.com', 'googleads.g.doubleclick.net', 'www.google.com', 'www.google.*', 'www.googletagmanager.com'],
+        domains: ['www.google-analytics.com', 'region1.google-analytics.com', 'analytics.google.com', 'stats.g.doubleclick.net', 'pagead2.googlesyndication.com', 'www.googleadservices.com', 'googleads.g.doubleclick.net', 'www.google.com', 'www.google.*', 'www.googletagmanager.com'],
         privacy: PRIVACY_HEATMAP,
       },
       partytown: { forwards: ['dataLayer.push', 'gtag'] },


### PR DESCRIPTION
### 🔗 Linked issue

resolves #752 

### 📚 Description

This PR adds the `region1.google-analytics.com` domain used by GA in some regions to the allow 


