### PR TITLE
chore: move top-level Google Maps `center`/`zoom` examples under `map-options`

### DIFF
--- a/docs/content/scripts/google-maps/1.guides/1.performance.md
+++ b/docs/content/scripts/google-maps/1.guides/1.performance.md
@@ -16,7 +16,7 @@ By default, the map loads on `mouseenter`, `mouseover`, or `mousedown`. Most pag
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 12
+      zoom: 12,
     }"
   />
 </template>
@@ -32,7 +32,7 @@ Forces the JavaScript API to load with the page. Use this only when the map is t
     trigger="immediate"
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 12
+      zoom: 12,
     }"
   />
 </template>

--- a/docs/content/scripts/google-maps/1.guides/1.performance.md
+++ b/docs/content/scripts/google-maps/1.guides/1.performance.md
@@ -14,8 +14,10 @@ By default, the map loads on `mouseenter`, `mouseover`, or `mousedown`. Most pag
 <template>
   <!-- Loads JS API on first hover/click -->
   <ScriptGoogleMaps
-    :center="{ lat: -33.8688, lng: 151.2093 }"
-    :zoom="12"
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 12
+    }"
   />
 </template>
 ```
@@ -28,8 +30,10 @@ Forces the JavaScript API to load with the page. Use this only when the map is t
 <template>
   <ScriptGoogleMaps
     trigger="immediate"
-    :center="{ lat: -33.8688, lng: 151.2093 }"
-    :zoom="12"
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 12
+    }"
   />
 </template>
 ```

--- a/docs/content/scripts/google-maps/1.guides/2.map-styling.md
+++ b/docs/content/scripts/google-maps/1.guides/2.map-styling.md
@@ -59,9 +59,11 @@ Google's [Map Styling](https://developers.google.com/maps/documentation/cloud-cu
 ```vue
 <template>
   <ScriptGoogleMaps
-    :map-options="{ mapId: 'YOUR_MAP_ID' }"
-    :center="{ lat: -33.8688, lng: 151.2093 }"
-    :zoom="12"
+    :map-options="{
+      mapId: 'YOUR_MAP_ID',
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 12
+    }"
   />
 </template>
 ```
@@ -78,8 +80,10 @@ Switch map styles automatically based on the user's color mode preference. Provi
 <template>
   <ScriptGoogleMaps
     :map-ids="{ light: 'LIGHT_MAP_ID', dark: 'DARK_MAP_ID' }"
-    :center="{ lat: -33.8688, lng: 151.2093 }"
-    :zoom="12"
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 12
+    }"
   />
 </template>
 ```
@@ -90,8 +94,10 @@ If you set up a single Map ID in Google Cloud Console with both Light and Dark c
 <template>
   <ScriptGoogleMaps
     :map-ids="{ light: 'YOUR_MAP_ID', dark: 'YOUR_MAP_ID' }"
-    :center="{ lat: -33.8688, lng: 151.2093 }"
-    :zoom="12"
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 12
+    }"
   />
 </template>
 ```

--- a/docs/content/scripts/google-maps/1.guides/2.map-styling.md
+++ b/docs/content/scripts/google-maps/1.guides/2.map-styling.md
@@ -62,7 +62,7 @@ Google's [Map Styling](https://developers.google.com/maps/documentation/cloud-cu
     :map-options="{
       mapId: 'YOUR_MAP_ID',
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 12
+      zoom: 12,
     }"
   />
 </template>
@@ -82,7 +82,7 @@ Switch map styles automatically based on the user's color mode preference. Provi
     :map-ids="{ light: 'LIGHT_MAP_ID', dark: 'DARK_MAP_ID' }"
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 12
+      zoom: 12,
     }"
   />
 </template>
@@ -96,7 +96,7 @@ If you set up a single Map ID in Google Cloud Console with both Light and Dark c
     :map-ids="{ light: 'YOUR_MAP_ID', dark: 'YOUR_MAP_ID' }"
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 12
+      zoom: 12,
     }"
   />
 </template>

--- a/docs/content/scripts/google-maps/1.guides/4.markers-and-info-windows.md
+++ b/docs/content/scripts/google-maps/1.guides/4.markers-and-info-windows.md
@@ -21,7 +21,7 @@ const greenPin = {
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8600, lng: 151.2100 },
-      zoom: 14
+      zoom: 14,
     }"
   >
     <!-- Simple marker with info window -->
@@ -76,7 +76,7 @@ const greenPin = {
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarker
@@ -98,7 +98,7 @@ Use the `#content` slot to customize the pin appearance.
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarker :position="{ lat: -33.8568, lng: 151.2153 }">
@@ -124,7 +124,7 @@ The `#content` slot replaces the default pin with any Vue template. Useful for p
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarker
@@ -151,7 +151,7 @@ The `#content` slot replaces the default pin with any Vue template. Useful for p
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarker :position="{ lat: -33.8568, lng: 151.2153 }">
@@ -179,7 +179,7 @@ const showPopup = ref(false)
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarker
@@ -228,7 +228,7 @@ function addMarker() {
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarker

--- a/docs/content/scripts/google-maps/1.guides/4.markers-and-info-windows.md
+++ b/docs/content/scripts/google-maps/1.guides/4.markers-and-info-windows.md
@@ -18,7 +18,12 @@ const greenPin = {
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.8600, lng: 151.2100 }" :zoom="14">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.8600, lng: 151.2100 },
+      zoom: 14
+    }"
+  >
     <!-- Simple marker with info window -->
     <ScriptGoogleMapsMarker :position="{ lat: -33.8568, lng: 151.2153 }">
       <ScriptGoogleMapsInfoWindow>
@@ -68,7 +73,12 @@ const greenPin = {
 
 ```vue
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.8688, lng: 151.2093 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarker
       :position="{ lat: -33.8568, lng: 151.2153 }"
     />
@@ -85,7 +95,12 @@ Use the `#content` slot to customize the pin appearance.
 
 ```vue
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.8688, lng: 151.2093 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarker :position="{ lat: -33.8568, lng: 151.2153 }">
       <template #content>
         <div class="w-7 h-7 rounded-full border-2 bg-[#FF0000] border-[#CC0000]" />
@@ -106,7 +121,12 @@ The `#content` slot replaces the default pin with any Vue template. Useful for p
 
 ```vue
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.8688, lng: 151.2093 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarker
       v-for="listing in listings"
       :key="listing.id"
@@ -128,7 +148,12 @@ The `#content` slot replaces the default pin with any Vue template. Useful for p
 
 ```vue
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.8688, lng: 151.2093 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarker :position="{ lat: -33.8568, lng: 151.2153 }">
       <ScriptGoogleMapsInfoWindow>
         <h3>Sydney Opera House</h3>
@@ -151,7 +176,12 @@ const showPopup = ref(false)
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.8688, lng: 151.2093 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarker
       :position="{ lat: -33.8688, lng: 151.2093 }"
       @click="showPopup = !showPopup"
@@ -195,7 +225,12 @@ function addMarker() {
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.8688, lng: 151.2093 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarker
       v-for="pos in markers"
       :key="`${pos.lat},${pos.lng}`"

--- a/docs/content/scripts/google-maps/1.guides/5.shapes-and-overlays.md
+++ b/docs/content/scripts/google-maps/1.guides/5.shapes-and-overlays.md
@@ -59,7 +59,12 @@ const rectangleOptions = {
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.863, lng: 151.210 }" :zoom="14">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.863, lng: 151.210 },
+      zoom: 14
+    }"
+  >
     <ScriptGoogleMapsCircle :options="circleOptions" />
     <ScriptGoogleMapsPolygon :options="polygonOptions" />
     <ScriptGoogleMapsPolyline :options="polylineOptions" />
@@ -90,7 +95,12 @@ const circleOptions = {
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="center" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center,
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarker :position="center" />
     <ScriptGoogleMapsCircle :options="circleOptions" />
   </ScriptGoogleMaps>
@@ -119,7 +129,12 @@ const polygonOptions = {
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.865, lng: 151.210 }" :zoom="14">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.865, lng: 151.210 },
+      zoom: 14
+    }"
+  >
     <ScriptGoogleMapsPolygon :options="polygonOptions" />
   </ScriptGoogleMaps>
 </template>
@@ -148,7 +163,12 @@ const endColor = '#ea4335'
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.862, lng: 151.212 }" :zoom="15">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.862, lng: 151.212 },
+      zoom: 15
+    }"
+  >
     <ScriptGoogleMapsPolyline :options="polylineOptions" />
     <ScriptGoogleMapsMarker :position="routePath[0]">
       <template #content>
@@ -183,7 +203,12 @@ const rectangleOptions = {
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.865, lng: 151.210 }" :zoom="14">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.865, lng: 151.210 },
+      zoom: 14
+    }"
+  >
     <ScriptGoogleMapsRectangle :options="rectangleOptions" />
   </ScriptGoogleMaps>
 </template>
@@ -224,7 +249,12 @@ const geoJsonStyle = {
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.885, lng: 151.225 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.885, lng: 151.225 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsGeoJson :src="geoJson" :style="geoJsonStyle" />
   </ScriptGoogleMaps>
 </template>
@@ -242,7 +272,12 @@ const geoJsonStyle = {
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.885, lng: 151.225 }" :zoom="10">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.885, lng: 151.225 },
+      zoom: 10
+    }"
+  >
     <ScriptGoogleMapsGeoJson
       src="https://example.com/boundaries.geojson"
       :style="geoJsonStyle"

--- a/docs/content/scripts/google-maps/1.guides/5.shapes-and-overlays.md
+++ b/docs/content/scripts/google-maps/1.guides/5.shapes-and-overlays.md
@@ -62,7 +62,7 @@ const rectangleOptions = {
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.863, lng: 151.210 },
-      zoom: 14
+      zoom: 14,
     }"
   >
     <ScriptGoogleMapsCircle :options="circleOptions" />
@@ -98,7 +98,7 @@ const circleOptions = {
   <ScriptGoogleMaps
     :map-options="{
       center,
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarker :position="center" />
@@ -132,7 +132,7 @@ const polygonOptions = {
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.865, lng: 151.210 },
-      zoom: 14
+      zoom: 14,
     }"
   >
     <ScriptGoogleMapsPolygon :options="polygonOptions" />
@@ -166,7 +166,7 @@ const endColor = '#ea4335'
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.862, lng: 151.212 },
-      zoom: 15
+      zoom: 15,
     }"
   >
     <ScriptGoogleMapsPolyline :options="polylineOptions" />
@@ -206,7 +206,7 @@ const rectangleOptions = {
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.865, lng: 151.210 },
-      zoom: 14
+      zoom: 14,
     }"
   >
     <ScriptGoogleMapsRectangle :options="rectangleOptions" />
@@ -252,7 +252,7 @@ const geoJsonStyle = {
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.885, lng: 151.225 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsGeoJson :src="geoJson" :style="geoJsonStyle" />
@@ -275,7 +275,7 @@ const geoJsonStyle = {
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.885, lng: 151.225 },
-      zoom: 10
+      zoom: 10,
     }"
   >
     <ScriptGoogleMapsGeoJson

--- a/docs/content/scripts/google-maps/1.guides/6.marker-clustering.md
+++ b/docs/content/scripts/google-maps/1.guides/6.marker-clustering.md
@@ -23,7 +23,7 @@ const locations = [
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.863, lng: 151.210 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarkerClusterer>
@@ -73,7 +73,7 @@ const locations = [
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.863, lng: 151.210 },
-      zoom: 14
+      zoom: 14,
     }"
   >
     <ScriptGoogleMapsMarkerClusterer>
@@ -131,7 +131,7 @@ const locations = [
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.863, lng: 151.210 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarkerClusterer>
@@ -159,7 +159,7 @@ Use the `#renderer` slot on the clusterer to fully customize cluster visuals wit
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.863, lng: 151.210 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsMarkerClusterer>
@@ -204,7 +204,7 @@ const listings = [
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.863, lng: 151.212 },
-      zoom: 14
+      zoom: 14,
     }"
   >
     <ScriptGoogleMapsMarkerClusterer>

--- a/docs/content/scripts/google-maps/1.guides/6.marker-clustering.md
+++ b/docs/content/scripts/google-maps/1.guides/6.marker-clustering.md
@@ -20,7 +20,12 @@ const locations = [
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.863, lng: 151.210 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.863, lng: 151.210 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarkerClusterer>
       <ScriptGoogleMapsMarker
         v-for="loc in locations"
@@ -65,7 +70,12 @@ const locations = [
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.863, lng: 151.210 }" :zoom="14">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.863, lng: 151.210 },
+      zoom: 14
+    }"
+  >
     <ScriptGoogleMapsMarkerClusterer>
       <ScriptGoogleMapsMarker
         v-for="loc in locations"
@@ -118,7 +128,12 @@ const locations = [
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.863, lng: 151.210 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.863, lng: 151.210 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarkerClusterer>
       <ScriptGoogleMapsMarker
         v-for="loc in locations"
@@ -141,7 +156,12 @@ Use the `#renderer` slot on the clusterer to fully customize cluster visuals wit
 
 ```vue
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.863, lng: 151.210 }" :zoom="13">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.863, lng: 151.210 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsMarkerClusterer>
       <template #renderer="{ cluster }">
         <div
@@ -181,7 +201,12 @@ const listings = [
 </script>
 
 <template>
-  <ScriptGoogleMaps :center="{ lat: -33.863, lng: 151.212 }" :zoom="14">
+  <ScriptGoogleMaps
+    :map-options="{
+      center: { lat: -33.863, lng: 151.212 },
+      zoom: 14
+    }"
+  >
     <ScriptGoogleMapsMarkerClusterer>
       <ScriptGoogleMapsMarker
         v-for="listing in listings"

--- a/docs/content/scripts/google-maps/2.api/1.script-google-maps.md
+++ b/docs/content/scripts/google-maps/2.api/1.script-google-maps.md
@@ -143,7 +143,12 @@ The placeholder slot is empty by default. Use [`<ScriptGoogleMapsStaticMap>`{lan
 
 ```vue
 <template>
-  <ScriptGoogleMaps :center="center" :zoom="7">
+  <ScriptGoogleMaps
+    :map-options="{
+      center,
+      zoom: 7
+    }"
+  >
     <template #placeholder>
       <ScriptGoogleMapsStaticMap
         :center="center"

--- a/docs/content/scripts/google-maps/2.api/1.script-google-maps.md
+++ b/docs/content/scripts/google-maps/2.api/1.script-google-maps.md
@@ -146,7 +146,7 @@ The placeholder slot is empty by default. Use [`<ScriptGoogleMapsStaticMap>`{lan
   <ScriptGoogleMaps
     :map-options="{
       center,
-      zoom: 7
+      zoom: 7,
     }"
   >
     <template #placeholder>

--- a/docs/content/scripts/google-maps/2.api/1b.static-map.md
+++ b/docs/content/scripts/google-maps/2.api/1b.static-map.md
@@ -37,7 +37,7 @@ Use inside [`<ScriptGoogleMaps>`{lang="html"}](/scripts/google-maps/api/script-g
   <ScriptGoogleMaps
     :map-options="{
       center,
-      zoom: 7
+      zoom: 7,
     }"
   >
     <template #placeholder>

--- a/docs/content/scripts/google-maps/2.api/1b.static-map.md
+++ b/docs/content/scripts/google-maps/2.api/1b.static-map.md
@@ -34,7 +34,12 @@ Use inside [`<ScriptGoogleMaps>`{lang="html"}](/scripts/google-maps/api/script-g
 
 ```vue
 <template>
-  <ScriptGoogleMaps :center="center" :zoom="7">
+  <ScriptGoogleMaps
+    :map-options="{
+      center,
+      zoom: 7
+    }"
+  >
     <template #placeholder>
       <ScriptGoogleMapsStaticMap
         :center="center"

--- a/docs/content/scripts/google-maps/2.api/2.marker.md
+++ b/docs/content/scripts/google-maps/2.api/2.marker.md
@@ -75,7 +75,13 @@ const locations = [
 </script>
 
 <template>
-  <ScriptGoogleMaps api-key="your-api-key" :center="{ lat: -35.5, lng: 148 }" :zoom="5">
+  <ScriptGoogleMaps
+    api-key="your-api-key"
+    :map-options="{
+      center: { lat: -35.5, lng: 148 },
+      zoom: 5
+    }"
+  >
     <ScriptGoogleMapsMarker
       v-for="loc in locations"
       :key="loc.id"

--- a/docs/content/scripts/google-maps/2.api/2.marker.md
+++ b/docs/content/scripts/google-maps/2.api/2.marker.md
@@ -79,7 +79,7 @@ const locations = [
     api-key="your-api-key"
     :map-options="{
       center: { lat: -35.5, lng: 148 },
-      zoom: 5
+      zoom: 5,
     }"
   >
     <ScriptGoogleMapsMarker

--- a/docs/content/scripts/google-maps/2.api/4.marker-clusterer.md
+++ b/docs/content/scripts/google-maps/2.api/4.marker-clusterer.md
@@ -33,7 +33,7 @@ const locations = ref([
     api-key="your-api-key"
     :map-options="{
       center: { lat: -33.86, lng: 151.24 },
-      zoom: 12
+      zoom: 12,
     }"
   >
     <ScriptGoogleMapsMarkerClusterer>

--- a/docs/content/scripts/google-maps/2.api/4.marker-clusterer.md
+++ b/docs/content/scripts/google-maps/2.api/4.marker-clusterer.md
@@ -29,7 +29,13 @@ const locations = ref([
 </script>
 
 <template>
-  <ScriptGoogleMaps api-key="your-api-key" :center="{ lat: -33.86, lng: 151.24 }" :zoom="12">
+  <ScriptGoogleMaps
+    api-key="your-api-key"
+    :map-options="{
+      center: { lat: -33.86, lng: 151.24 },
+      zoom: 12
+    }"
+  >
     <ScriptGoogleMapsMarkerClusterer>
       <ScriptGoogleMapsMarker
         v-for="location in locations"

--- a/docs/content/scripts/google-maps/2.api/6.polygon.md
+++ b/docs/content/scripts/google-maps/2.api/6.polygon.md
@@ -34,7 +34,13 @@ Pass an array of arrays to `paths` to cut holes in the polygon. The first array 
 
 ```vue
 <template>
-  <ScriptGoogleMaps api-key="your-api-key" :center="{ lat: -34.404, lng: 150.644 }" :zoom="14">
+  <ScriptGoogleMaps
+    api-key="your-api-key"
+    :map-options="{
+      center: { lat: -34.404, lng: 150.644 },
+      zoom: 14
+    }"
+  >
     <ScriptGoogleMapsPolygon
       :options="{
         paths: [

--- a/docs/content/scripts/google-maps/2.api/6.polygon.md
+++ b/docs/content/scripts/google-maps/2.api/6.polygon.md
@@ -38,7 +38,7 @@ Pass an array of arrays to `paths` to cut holes in the polygon. The first array 
     api-key="your-api-key"
     :map-options="{
       center: { lat: -34.404, lng: 150.644 },
-      zoom: 14
+      zoom: 14,
     }"
   >
     <ScriptGoogleMapsPolygon

--- a/docs/content/scripts/google-maps/2.api/7.polyline.md
+++ b/docs/content/scripts/google-maps/2.api/7.polyline.md
@@ -38,7 +38,7 @@ Set `geodesic: true` to render lines that follow the curvature of the Earth. Imp
     api-key="your-api-key"
     :map-options="{
       center: { lat: 0, lng: 130 },
-      zoom: 3
+      zoom: 3,
     }"
   >
     <ScriptGoogleMapsPolyline

--- a/docs/content/scripts/google-maps/2.api/7.polyline.md
+++ b/docs/content/scripts/google-maps/2.api/7.polyline.md
@@ -34,7 +34,13 @@ Set `geodesic: true` to render lines that follow the curvature of the Earth. Imp
 
 ```vue
 <template>
-  <ScriptGoogleMaps api-key="your-api-key" :center="{ lat: 0, lng: 130 }" :zoom="3">
+  <ScriptGoogleMaps
+    api-key="your-api-key"
+    :map-options="{
+      center: { lat: 0, lng: 130 },
+      zoom: 3
+    }"
+  >
     <ScriptGoogleMapsPolyline
       :options="{
         path: [

--- a/docs/content/scripts/google-maps/2.api/9.geojson.md
+++ b/docs/content/scripts/google-maps/2.api/9.geojson.md
@@ -35,7 +35,13 @@ const geoJsonData = {
 </script>
 
 <template>
-  <ScriptGoogleMaps api-key="your-api-key" :center="{ lat: -33.885, lng: 151.225 }" :zoom="13">
+  <ScriptGoogleMaps
+    api-key="your-api-key"
+    :map-options="{
+      center: { lat: -33.885, lng: 151.225 },
+      zoom: 13
+    }"
+  >
     <ScriptGoogleMapsGeoJson
       :src="geoJsonData"
       :style="{ fillColor: '#4285F4', fillOpacity: 0.3, strokeColor: '#4285F4', strokeWeight: 2 }"

--- a/docs/content/scripts/google-maps/2.api/9.geojson.md
+++ b/docs/content/scripts/google-maps/2.api/9.geojson.md
@@ -39,7 +39,7 @@ const geoJsonData = {
     api-key="your-api-key"
     :map-options="{
       center: { lat: -33.885, lng: 151.225 },
-      zoom: 13
+      zoom: 13,
     }"
   >
     <ScriptGoogleMapsGeoJson

--- a/docs/content/scripts/google-maps/index.md
+++ b/docs/content/scripts/google-maps/index.md
@@ -74,8 +74,10 @@ See [Billing & Permissions](/scripts/google-maps/guides/billing) for API costs a
 ```vue
 <template>
   <ScriptGoogleMaps
-    :center="{ lat: -33.8688, lng: 151.2093 }"
-    :zoom="12"
+    :map-options="{
+      center: { lat: -33.8688, lng: 151.2093 },
+      zoom: 12
+    }"
   />
 </template>
 ```

--- a/docs/content/scripts/google-maps/index.md
+++ b/docs/content/scripts/google-maps/index.md
@@ -76,7 +76,7 @@ See [Billing & Permissions](/scripts/google-maps/guides/billing) for API costs a
   <ScriptGoogleMaps
     :map-options="{
       center: { lat: -33.8688, lng: 151.2093 },
-      zoom: 12
+      zoom: 12,
     }"
   />
 </template>

--- a/playground/pages/third-parties/google-maps/emit-test.vue
+++ b/playground/pages/third-parties/google-maps/emit-test.vue
@@ -62,9 +62,9 @@ const circleOptions = {
         api-key="AIzaSyAOEIQ_xOdLx2dNwnFMzyJoswwvPCTcGzU"
         :width="800"
         :height="500"
-        :zoom="12"
         :map-options="{
           center: { lat: -33.87, lng: 151.21 },
+          zoom: 12,
           mapId: 'DEMO_MAP_ID',
         }"
       >

--- a/playground/pages/third-parties/google-maps/geojson-test.vue
+++ b/playground/pages/third-parties/google-maps/geojson-test.vue
@@ -95,8 +95,10 @@ const secondGeoJson = {
         api-key="AIzaSyAOEIQ_xOdLx2dNwnFMzyJoswwvPCTcGzU"
         :width="800"
         :height="450"
-        :zoom="13"
-        :map-options="{ center: { lat: -33.875, lng: 151.22 } }"
+        :map-options="{
+          center: { lat: -33.875, lng: 151.22 },
+          zoom: 13
+        }"
       >
         <!-- Primary GeoJSON layer -->
         <ScriptGoogleMapsGeoJson

--- a/playground/pages/third-parties/google-maps/null.vue
+++ b/playground/pages/third-parties/google-maps/null.vue
@@ -19,7 +19,7 @@ function changeQuery() {
         api-key="AIzaSyAOEIQ_xOdLx2dNwnFMzyJoswwvPCTcGzU"
         :width="1200"
         :height="600"
-        :center="center"
+        :map-options="{ center }"
       />
     </div>
     <div class="button-container">

--- a/playground/pages/third-parties/google-maps/overlay-animated.vue
+++ b/playground/pages/third-parties/google-maps/overlay-animated.vue
@@ -32,11 +32,13 @@ function close(id: number) {
       Click a marker to open/close. Uses data-state attribute for CSS enter/leave animations.
     </p>
     <ScriptGoogleMaps
-      :center="{ lat: -33.8688, lng: 151.2093 }"
-      :zoom="12"
       :width="800"
       :height="500"
-      :map-options="{ mapId: 'DEMO_MAP_ID' }"
+      :map-options="{
+        mapId: 'DEMO_MAP_ID',
+        center: { lat: -33.8688, lng: 151.2093 },
+        zoom: 12
+      }"
     >
       <ScriptGoogleMapsMarker
         v-for="place in places"

--- a/playground/pages/third-parties/google-maps/overlay-popup.vue
+++ b/playground/pages/third-parties/google-maps/overlay-popup.vue
@@ -19,11 +19,13 @@ const places = [
       Click a marker to show a fully custom popup. Click again or press × to close. Uses v-if for multiple markers.
     </p>
     <ScriptGoogleMaps
-      :center="{ lat: -33.8688, lng: 151.2093 }"
-      :zoom="12"
       :width="800"
       :height="500"
-      :map-options="{ mapId: 'DEMO_MAP_ID' }"
+      :map-options="{
+        mapId: 'DEMO_MAP_ID',
+        center: { lat: -33.8688, lng: 151.2093 },
+        zoom: 12
+      }"
     >
       <ScriptGoogleMapsMarker
         v-for="place in places"

--- a/playground/pages/third-parties/google-maps/query.vue
+++ b/playground/pages/third-parties/google-maps/query.vue
@@ -20,7 +20,7 @@ function changeQuery() {
         api-key="AIzaSyAOEIQ_xOdLx2dNwnFMzyJoswwvPCTcGzU"
         :width="1200"
         :height="600"
-        :center="center"
+        :map-options="{ center }"
       />
     </div>
     <div class="button-container">


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Addresses deprecation of top-level `center`/`zoom` Google Maps opts by updating docs/playground examples.