### PR TITLE
fix: add `--pnpm` flag to `pkg-pr-new publish` command in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,4 +30,4 @@ jobs:
       - run: pnpm build
 
       - name: Publish
-        run: pnpm dlx pkg-pr-new publish ./packages/script
+        run: pnpx pkg-pr-new publish --pnpm ./packages/script


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Fixes broken nightly releases (a regression from https://github.com/nuxt/scripts/commit/7a6c2f823304261f20d6ddeba26b2332034841bc).