### PR TITLE
chore(calendly): address CodeRabbit follow-ups from #750

### DIFF
--- a/packages/script/src/runtime/components/ScriptCalendlyInlineWidget.vue
+++ b/packages/script/src/runtime/components/ScriptCalendlyInlineWidget.vue
@@ -92,7 +92,7 @@ onMounted(() => {
   watch(status, (s) => {
     if (s === 'error')
       emit('error')
-  })
+  }, { immediate: true })
 })
 
 const computedRootAttrs = computed<HTMLAttributes>(() => ({

--- a/packages/script/src/runtime/registry/calendly.ts
+++ b/packages/script/src/runtime/registry/calendly.ts
@@ -27,6 +27,7 @@ interface CalendlyPageSettings {
   backgroundColor?: string
   hideEventTypeDetails?: boolean
   hideLandingPageDetails?: boolean
+  hideGdprBanner?: boolean
   primaryColor?: string
   textColor?: string
 }
@@ -86,12 +87,9 @@ const CALENDLY_CLOSE_ICON = `data:image/svg+xml;charset=utf-8,${encodeURICompone
 
 const CALENDLY_CSS = `.calendly-badge-widget,.calendly-badge-widget *,.calendly-inline-widget,.calendly-inline-widget *,.calendly-overlay,.calendly-overlay *{font-size:16px;line-height:1.2em}.calendly-badge-widget iframe,.calendly-inline-widget iframe,.calendly-overlay iframe{display:inline;height:100%;width:100%}.calendly-popup-content{position:relative}.calendly-popup-content.calendly-mobile{-webkit-overflow-scrolling:touch;overflow-y:auto}.calendly-overlay{background-color:#a5a5a5;background-color:rgba(31,31,31,.4);bottom:0;left:0;overflow:hidden;position:fixed;right:0;top:0;z-index:9999}.calendly-overlay .calendly-close-overlay{bottom:0;left:0;position:absolute;right:0;top:0}.calendly-overlay .calendly-popup{box-sizing:border-box;height:90%;left:50%;max-height:700px!important;max-width:1000px;min-width:900px;position:absolute;top:50%;transform:translateY(-50%) translateX(-50%);width:80%}@media (max-width:975px){.calendly-overlay .calendly-popup{bottom:0;height:auto;left:0;max-height:none;min-width:0;position:fixed;right:0;top:50px;transform:none;width:100%}}.calendly-overlay .calendly-popup .calendly-popup-content{height:100%}.calendly-overlay .calendly-popup-close{background:url(${CALENDLY_CLOSE_ICON}) no-repeat;background-size:contain;color:#fff;cursor:pointer;height:19px;position:absolute;right:25px;top:25px;width:19px}@media (max-width:975px){.calendly-overlay .calendly-popup-close{right:15px;top:15px}}.calendly-badge-widget{bottom:15px;position:fixed;right:20px;z-index:9998}.calendly-badge-widget .calendly-badge-content{border-radius:25px;box-shadow:0 2px 5px rgba(0,0,0,.25);color:#fff;cursor:pointer;display:table-cell;font-family:sans-serif;font-size:14px;font-weight:700;height:45px;padding:0 30px;text-align:center;vertical-align:middle;width:auto}.calendly-badge-widget .calendly-badge-content.calendly-white{color:#666a73}.calendly-badge-widget .calendly-badge-content span{display:block;font-size:12px}.calendly-spinner{left:0;position:absolute;right:0;text-align:center;top:50%;transform:translateY(-50%);z-index:-1}.calendly-spinner>div{animation:calendly-bouncedelay 1.4s ease-in-out infinite;animation-fill-mode:both;background-color:#e1e1e1;border-radius:50%;display:inline-block;height:18px;vertical-align:middle;width:18px}.calendly-spinner .calendly-bounce1{animation-delay:-.32s}.calendly-spinner .calendly-bounce2{animation-delay:-.16s}@keyframes calendly-bouncedelay{0%,80%,to{transform:scale(0)}40%{transform:scale(1)}}`
 
-let cssInjected = false
-
 function ensureCalendlyStylesheet() {
-  if (import.meta.server || cssInjected)
+  if (import.meta.server)
     return
-  cssInjected = true
   useHead({
     style: [
       {


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #750.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Three issues raised by CodeRabbit on #750 that landed after the squash-merge:

#### 🟠 Major: stylesheet disappears after SPA navigation

The `cssInjected` module-level flag short-circuited `ensureCalendlyStylesheet()` after first injection. But because the `useHead` call runs inside the composable's `setup()`, the entry is component-scoped — unhead removes the `<style>` on unmount. On the next visit the flag still said "already injected", so the widget loaded unstyled.

Fix: drop the flag and rely on `key` deduplication. Multiple components on the same page calling `useHead` with the same `key` are safely collapsed to one `<style>` tag, and the entry follows the component lifecycle correctly across SPA navigations.

#### 🟡 Minor: `watch` on `status` missed pre-existing `'error'` state

A shared `useScriptCalendly()` instance that already failed (e.g. on a prior navigation) won't re-fire `status` change on a new component mount. The component never emits `error` for the existing failure. Added `{ immediate: true }`.

#### 🟡 Minor: `CalendlyPageSettings` missing `hideGdprBanner`

Calendly's SDK accepts it; the component's local copy of the interface had it but the registry's exported one didn't, so callers composing `CalendlyInlineWidgetOptions` / `CalendlyPopupWidgetOptions` directly couldn't pass the flag type-safely.

### ✅ Verification

- All Calendly e2e + unit + typecheck tests pass locally.
- SPA-navigation regression manually reproducible before the fix (navigate away from `/third-parties/calendly/nuxt-scripts`, navigate back → `<style>` was missing); fixed after.