### PR TITLE
fix: validate required registry fields after runtime merge

### DIFF
--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -665,7 +665,20 @@ export default defineNuxtModule<ModuleOptions>({
         const willAutoLoad = scriptOptions && 'trigger' in scriptOptions && scriptOptions.trigger !== false
         if (willAutoLoad) {
           const requiredFields = extractRequiredFields(script.schema)
-          const missing = requiredFields.filter(f => !input[f])
+
+          const publicScripts = (nuxt.options.runtimeConfig.public?.scripts ?? {}) as Record<string, Record<string, unknown>>
+          const publicScriptEntry = publicScripts[key]
+          const effectiveInput: Record<string, unknown>
+            = publicScriptEntry
+              && typeof publicScriptEntry === 'object'
+              && !Array.isArray(publicScriptEntry)
+              ? Object.fromEntries(
+                  Object.entries(publicScriptEntry).filter(([prop]) => prop !== 'scriptOptions'),
+                )
+              : input
+
+          const missing = requiredFields.filter(f => !effectiveInput[f])
+
           if (missing.length) {
             logger.warn(`[nuxt-scripts] registry.${key}: missing required field${missing.length > 1 ? 's' : ''} ${missing.map(f => `'${f}'`).join(', ')}. The script infrastructure is registered but will not function without ${missing.length > 1 ? 'them' : 'it'}.`)
           }

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -280,6 +280,20 @@ export function resolveConfiguredProxyDomains(
   return [...domains].sort()
 }
 
+/**
+ * Compute missing required fields for a registry entry, using the merged
+ * runtimeConfig as source of truth so that env vars and runtimeConfig.public.scripts
+ * count toward satisfying the schema.
+ */
+export function findMissingRequiredFields(
+  requiredFields: string[],
+  rawInput: Record<string, any> | undefined,
+  mergedPublicScript: Record<string, any> | undefined,
+): string[] {
+  const { scriptOptions: _, ...effectiveInput } = mergedPublicScript ?? rawInput ?? {}
+  return requiredFields.filter(f => !effectiveInput[f])
+}
+
 export interface ModuleOptions {
   /**
    * Base path prefix for all script endpoints (proxy and bundled assets).
@@ -665,20 +679,10 @@ export default defineNuxtModule<ModuleOptions>({
         const willAutoLoad = scriptOptions && 'trigger' in scriptOptions && scriptOptions.trigger !== false
         if (willAutoLoad) {
           const requiredFields = extractRequiredFields(script.schema)
-
-          const publicScripts = (nuxt.options.runtimeConfig.public?.scripts ?? {}) as Record<string, Record<string, unknown>>
-          const publicScriptEntry = publicScripts[key]
-          const effectiveInput: Record<string, unknown>
-            = publicScriptEntry
-              && typeof publicScriptEntry === 'object'
-              && !Array.isArray(publicScriptEntry)
-              ? Object.fromEntries(
-                  Object.entries(publicScriptEntry).filter(([prop]) => prop !== 'scriptOptions'),
-                )
-              : input
-
-          const missing = requiredFields.filter(f => !effectiveInput[f])
-
+          // Check the merged runtimeConfig (input + env defaults + NUXT_PUBLIC_SCRIPTS_*),
+          // not just the raw registry input — required fields may be supplied via env.
+          const publicScripts = (nuxt.options.runtimeConfig.public?.scripts ?? {}) as Record<string, Record<string, any>>
+          const missing = findMissingRequiredFields(requiredFields, input, publicScripts[key])
           if (missing.length) {
             logger.warn(`[nuxt-scripts] registry.${key}: missing required field${missing.length > 1 ? 's' : ''} ${missing.map(f => `'${f}'`).join(', ')}. The script infrastructure is registered but will not function without ${missing.length > 1 ? 'them' : 'it'}.`)
           }

--- a/test/unit/setup.test.ts
+++ b/test/unit/setup.test.ts
@@ -172,8 +172,4 @@ describe('findMissingRequiredFields', () => {
   it('returns only the still-missing subset', () => {
     expect(findMissingRequiredFields(['id', 'apiKey'], {}, { id: 'G-123' })).toEqual(['apiKey'])
   })
-
-  it('falls back to raw input when merged entry is absent', () => {
-    expect(findMissingRequiredFields(['id'], { id: 'G-123' }, undefined)).toEqual([])
-  })
 })

--- a/test/unit/setup.test.ts
+++ b/test/unit/setup.test.ts
@@ -1,6 +1,6 @@
 import type { NuxtConfigScriptRegistry } from '../../packages/script/src/runtime/types'
 import { describe, expect, it } from 'vitest'
-import { applyAutoInject, resolveConfiguredProxyDomains } from '../../packages/script/src/module'
+import { applyAutoInject, findMissingRequiredFields, resolveConfiguredProxyDomains } from '../../packages/script/src/module'
 
 describe('applyAutoInject', () => {
   const posthogAutoInject = {
@@ -147,5 +147,33 @@ describe('resolveConfiguredProxyDomains', () => {
       },
       configDomainFields: ['scriptUrl'],
     })).toEqual(['cdn.analytics.example.com', 'events.analytics.example.com'])
+  })
+})
+
+describe('findMissingRequiredFields', () => {
+  it('flags fields missing from both raw input and merged runtimeConfig', () => {
+    expect(findMissingRequiredFields(['id'], {}, undefined)).toEqual(['id'])
+  })
+
+  it('treats fields satisfied via raw input as present', () => {
+    expect(findMissingRequiredFields(['id'], { id: 'G-123' }, undefined)).toEqual([])
+  })
+
+  it('treats fields supplied only via merged runtimeConfig.public.scripts as present', () => {
+    // Reproduces #761: id arrives via NUXT_PUBLIC_SCRIPTS_* / runtimeConfig and is
+    // merged into runtimeConfig.public.scripts before validation runs.
+    expect(findMissingRequiredFields(['id'], {}, { id: 'G-123' })).toEqual([])
+  })
+
+  it('ignores `scriptOptions` carried on the merged entry', () => {
+    expect(findMissingRequiredFields(['id'], {}, { scriptOptions: { bundle: true } })).toEqual(['id'])
+  })
+
+  it('returns only the still-missing subset', () => {
+    expect(findMissingRequiredFields(['id', 'apiKey'], {}, { id: 'G-123' })).toEqual(['apiKey'])
+  })
+
+  it('falls back to raw input when merged entry is absent', () => {
+    expect(findMissingRequiredFields(['id'], { id: 'G-123' }, undefined)).toEqual([])
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/scripts/issues/761

### 📚 Description

Required-field validation during module setup compared the Valibot schema to the normalized `[input]` from `scripts.registry` only.

IDs and similar fields are often supplied only through `runtimeConfig.public.scripts` and/or `NUXT_PUBLIC_SCRIPTS_*`, merged into `public.scripts` earlier in this module (`registryWithDefaults` + `defu`). After that merge, the effective config already includes `id`, but the check still complained.

The WARN now inspects each script’s merged object in `runtimeConfig.public.scripts`, dropping `scriptOptions` keys that aren’t part of script input schema. Behaviour at runtime is unchanged; this only aligns dev warnings with documented env/runtime configuration.
