### PR TITLE
fix(googleTagManager): push consent as arguments to dataLayer

### DIFF
--- a/packages/script/src/runtime/registry/google-tag-manager.ts
+++ b/packages/script/src/runtime/registry/google-tag-manager.ts
@@ -81,7 +81,7 @@ export { GoogleTagManagerOptions }
 export type GoogleTagManagerInput = RegistryScriptInput<typeof GoogleTagManagerOptions>
 
 export interface GoogleTagManagerConsent {
-  /** Push `['consent','update', state]` onto dataLayer with GCMv2 partial state. */
+  /** Send `gtag('consent','update', state)` so the dataLayer receives consent command (GCMv2 partial state). */
   update: (state: ConsentState) => void
 }
 
@@ -97,6 +97,8 @@ export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(
     onBeforeGtmStart?: (gtag: DataLayerPush) => void
   },
 ): UseScriptContext<UseFunctionType<NuxtUseScriptOptions<T>, T>, GoogleTagManagerConsent> {
+  const consentDataLayerName = options?.l ?? options?.dataLayer ?? 'dataLayer'
+
   const instance = useRegistryScript<T, typeof GoogleTagManagerOptions>(
     options?.key || 'googleTagManager',
     (opts) => {
@@ -136,7 +138,7 @@ export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(
               // not a spread array — so GTM processes consent and
               // other commands like the official snippet)
               function gtag(..._args: any[]) {
-                // Rest params satisfy TypeScript call sites; gtag.js expects `arguments` on the queue.
+                // Rest params satisfy TypeScript call sites; gtm expects `arguments` on the queue.
                 // eslint-disable-next-line prefer-rest-params
                 (window as any)[dataLayerName].push(arguments)
               }
@@ -179,7 +181,15 @@ export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(
   if (import.meta.client && !typed.consent) {
     typed.consent = {
       update: (state: ConsentState) => {
-        ;((typed.proxy as unknown as GoogleTagManagerApi).dataLayer as any).push(['consent', 'update', state])
+        const dl = (window as any)[consentDataLayerName] = (window as any)[consentDataLayerName] || []
+        // Must push the real `arguments` object — not a
+        // spread array — so GTM processes consent and
+        // other commands like the official snippet
+        ;(function (..._args: any[]) {
+          // Rest params satisfy TypeScript call sites; gtm expects `arguments` on the queue.
+          // eslint-disable-next-line prefer-rest-params
+          dl.push(arguments)
+        })('consent', 'update', state)
       },
     }
   }

--- a/packages/script/src/runtime/registry/google-tag-manager.ts
+++ b/packages/script/src/runtime/registry/google-tag-manager.ts
@@ -132,10 +132,13 @@ export function useScriptGoogleTagManager<T extends GoogleTagManagerApi>(
               // Initialize dataLayer if it doesn't exist
               (window as any)[dataLayerName] = (window as any)[dataLayerName] || []
 
-              // Create gtag function
-              function gtag(...args: any[]) {
-                // Pushing arguments to dataLayer is necessary for GTM to process events
-                (window as any)[dataLayerName].push(args)
+              // Create gtag function (must push the real `arguments` object —
+              // not a spread array — so GTM processes consent and
+              // other commands like the official snippet)
+              function gtag(..._args: any[]) {
+                // Rest params satisfy TypeScript call sites; gtag.js expects `arguments` on the queue.
+                // eslint-disable-next-line prefer-rest-params
+                (window as any)[dataLayerName].push(arguments)
               }
 
               // Assign gtag to window for global access

--- a/test/nuxt-runtime/consent-default.nuxt.test.ts
+++ b/test/nuxt-runtime/consent-default.nuxt.test.ts
@@ -379,14 +379,24 @@ describe('per-script consent object', () => {
     expect(updateArgs?.[2]).toEqual({ ad_storage: 'granted' })
   })
 
-  it('gtm: consent.update() pushes ["consent","update", state] onto dataLayer', async () => {
+  it('gtm: consent.update() queues Arguments(consent, update, state) to dataLayer', async () => {
     ;(window as any).dataLayer = []
     const { useScriptGoogleTagManager } = await import('../../packages/script/src/runtime/registry/google-tag-manager')
     const result: any = useScriptGoogleTagManager({ id: 'GTM-XXXX' })
     result._opts.clientInit()
     result.consent.update({ analytics_storage: 'granted' })
     const dl = (window as any).dataLayer as any[]
-    expect(dl).toContainEqual(['consent', 'update', { analytics_storage: 'granted' }])
+    const entry = dl.find((e) => {
+      const row = Array.isArray(e)
+        ? e
+        : (e != null && typeof e === 'object' && 'length' in e
+            ? Array.from(e as ArrayLike<any>)
+            : [])
+      return row[0] === 'consent' && row[1] === 'update'
+    })
+    expect(entry).toBeDefined()
+    expect(Array.isArray(entry)).toBe(false)
+    expect(Array.from(entry as ArrayLike<any>)).toEqual(['consent', 'update', { analytics_storage: 'granted' }])
   })
 
   it('meta: consent.grant()/revoke() queue fbq(\'consent\', ...) calls', async () => {

--- a/test/nuxt-runtime/consent-default.nuxt.test.ts
+++ b/test/nuxt-runtime/consent-default.nuxt.test.ts
@@ -51,19 +51,19 @@ vi.mock('../../packages/script/src/runtime/composables/useScriptEventPage', () =
   useScriptEventPage: vi.fn(),
 }))
 
-describe('consent defaults — clientInit ordering', () => {
-  /** `gtag()` queues the Arguments object; `dataLayer.push([...])` uses a real Array. */
-  function gtmConsentCommandParts(e: any): [string, string, any?] | null {
-    if (e == null || typeof e !== 'object')
-      return null
-    if (!Array.isArray(e) && !('length' in e && typeof (e as any).length === 'number'))
-      return null
-    const row = Array.isArray(e) ? e : Array.from(e as ArrayLike<any>)
-    if (row[0] !== 'consent')
-      return null
-    return [row[0] as string, row[1] as string, row[2]]
-  }
+/** `gtag()` queues the Arguments object; `dataLayer.push([...])` uses a real Array. */
+function gtmConsentCommandParts(e: any): [string, string, any?] | null {
+  if (e == null || typeof e !== 'object')
+    return null
+  if (!Array.isArray(e) && !('length' in e && typeof (e as any).length === 'number'))
+    return null
+  const row = Array.isArray(e) ? e : Array.from(e as ArrayLike<any>)
+  if (row[0] !== 'consent')
+    return null
+  return [row[0] as string, row[1] as string, row[2]]
+}
 
+describe('consent defaults — clientInit ordering', () => {
   beforeEach(() => {
     delete (window as any).dataLayer
     delete (window as any)._paq
@@ -386,17 +386,10 @@ describe('per-script consent object', () => {
     result._opts.clientInit()
     result.consent.update({ analytics_storage: 'granted' })
     const dl = (window as any).dataLayer as any[]
-    const entry = dl.find((e) => {
-      const row = Array.isArray(e)
-        ? e
-        : (e != null && typeof e === 'object' && 'length' in e
-            ? Array.from(e as ArrayLike<any>)
-            : [])
-      return row[0] === 'consent' && row[1] === 'update'
-    })
+    const entry = dl.find(e => gtmConsentCommandParts(e)?.[1] === 'update')
     expect(entry).toBeDefined()
     expect(Array.isArray(entry)).toBe(false)
-    expect(Array.from(entry as ArrayLike<any>)).toEqual(['consent', 'update', { analytics_storage: 'granted' }])
+    expect(gtmConsentCommandParts(entry)).toEqual(['consent', 'update', { analytics_storage: 'granted' }])
   })
 
   it('meta: consent.grant()/revoke() queue fbq(\'consent\', ...) calls', async () => {

--- a/test/nuxt-runtime/consent-default.nuxt.test.ts
+++ b/test/nuxt-runtime/consent-default.nuxt.test.ts
@@ -52,6 +52,18 @@ vi.mock('../../packages/script/src/runtime/composables/useScriptEventPage', () =
 }))
 
 describe('consent defaults — clientInit ordering', () => {
+  /** `gtag()` queues the Arguments object; `dataLayer.push([...])` uses a real Array. */
+  function gtmConsentCommandParts(e: any): [string, string, any?] | null {
+    if (e == null || typeof e !== 'object')
+      return null
+    if (!Array.isArray(e) && !('length' in e && typeof (e as any).length === 'number'))
+      return null
+    const row = Array.isArray(e) ? e : Array.from(e as ArrayLike<any>)
+    if (row[0] !== 'consent')
+      return null
+    return [row[0] as string, row[1] as string, row[2]]
+  }
+
   beforeEach(() => {
     delete (window as any).dataLayer
     delete (window as any)._paq
@@ -72,13 +84,14 @@ describe('consent defaults — clientInit ordering', () => {
     const dl = (window as any).dataLayer as any[]
     expect(Array.isArray(dl)).toBe(true)
 
-    const consentIdx = dl.findIndex(e => Array.isArray(e) && e[0] === 'consent' && e[1] === 'default')
+    const consentIdx = dl.findIndex(e => gtmConsentCommandParts(e)?.[1] === 'default')
     const startIdx = dl.findIndex(e => e && typeof e === 'object' && !Array.isArray(e) && e.event === 'gtm.js')
 
     expect(consentIdx).toBeGreaterThanOrEqual(0)
     expect(startIdx).toBeGreaterThanOrEqual(0)
     expect(consentIdx).toBeLessThan(startIdx)
-    expect(dl[consentIdx][2]).toMatchObject({ analytics_storage: 'denied', ad_storage: 'denied' })
+    const consentRow = gtmConsentCommandParts(dl[consentIdx])
+    expect(consentRow?.[2]).toMatchObject({ analytics_storage: 'denied', ad_storage: 'denied' })
   })
 
   it('gtm: array form fires multiple ["consent","default",…] entries in input order, all before gtm.js', async () => {
@@ -98,14 +111,14 @@ describe('consent defaults — clientInit ordering', () => {
 
     const consentEntries = dl
       .map((e, i) => ({ e, i }))
-      .filter(({ e }) => Array.isArray(e) && e[0] === 'consent' && e[1] === 'default')
+      .filter(({ e }) => gtmConsentCommandParts(e)?.[1] === 'default')
     const startIdx = dl.findIndex(e => e && typeof e === 'object' && !Array.isArray(e) && e.event === 'gtm.js')
 
     expect(consentEntries).toHaveLength(2)
     expect(startIdx).toBeGreaterThanOrEqual(0)
     for (const { i } of consentEntries) expect(i).toBeLessThan(startIdx)
-    expect(consentEntries[0].e[2]).toMatchObject({ analytics_storage: 'denied', region: ['ES', 'US-AK'], wait_for_update: 500 })
-    expect(consentEntries[1].e[2]).toMatchObject({ ad_storage: 'denied' })
+    expect(gtmConsentCommandParts(consentEntries[0].e)?.[2]).toMatchObject({ analytics_storage: 'denied', region: ['ES', 'US-AK'], wait_for_update: 500 })
+    expect(gtmConsentCommandParts(consentEntries[1].e)?.[2]).toMatchObject({ ad_storage: 'denied' })
   })
 
   it('gtm: single-entry array is observationally equivalent to a bare object', async () => {
@@ -120,6 +133,14 @@ describe('consent defaults — clientInit ordering', () => {
       // Slice up to (but not including) gtm.js — the entry carries a Date.now() timestamp
       // that differs between calls. Ordering relative to gtm.js is locked by the sibling test.
       return dl.slice(0, startIdx)
+        // `gtag()` pushes the Arguments object onto dataLayer, so each run yields distinct exotic
+        // objects. Normalize array-like rows to real arrays so `toEqual` compares values only,
+        // not Arguments identity or matcher quirks across two separate `clientInit` runs.
+        .map(e =>
+          e != null && typeof e === 'object' && !Array.isArray(e) && 'length' in e && typeof (e as any).length === 'number'
+            ? Array.from(e as ArrayLike<any>)
+            : e,
+        )
     }
 
     const fromObject = runWith({ ad_storage: 'denied' })
@@ -135,11 +156,30 @@ describe('consent defaults — clientInit ordering', () => {
     result._opts.clientInit()
 
     const dl = (window as any).dataLayer as any[]
-    const consentEntries = dl.filter(e => Array.isArray(e) && e[0] === 'consent' && e[1] === 'default')
+    const consentEntries = dl.filter(e => gtmConsentCommandParts(e)?.[1] === 'default')
     const startIdx = dl.findIndex(e => e && typeof e === 'object' && !Array.isArray(e) && e.event === 'gtm.js')
 
     expect(consentEntries).toHaveLength(0)
     expect(startIdx).toBeGreaterThanOrEqual(0)
+  })
+
+  it('gtm: defaultConsent via gtag queues Arguments, not a plain Array (gtag.js contract)', async () => {
+    const { useScriptGoogleTagManager } = await import('../../packages/script/src/runtime/registry/google-tag-manager')
+    const result: any = useScriptGoogleTagManager({
+      id: 'GTM-XXXX',
+      defaultConsent: { analytics_storage: 'denied' },
+    })
+
+    result._opts.clientInit()
+
+    const dl = (window as any).dataLayer as any[]
+    const entry = dl.find(e => gtmConsentCommandParts(e)?.[1] === 'default')
+    expect(entry).toBeDefined()
+    expect(Array.isArray(entry)).toBe(false)
+    const parts = Array.from(entry as ArrayLike<any>)
+    expect(parts[0]).toBe('consent')
+    expect(parts[1]).toBe('default')
+    expect(parts[2]).toMatchObject({ analytics_storage: 'denied' })
   })
 
   it('matomo: "required" pushes requireConsent before setSiteId', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/scripts/issues/770

(Related context: [discussion #745](https://github.com/nuxt/scripts/discussions/745).)

### 📚 Description

⚠️ **AI Disclaimer**: I used AI assistance but the description and code match what I personally verified locally. Let me know if you've got any questions or if you need further reproduction samples.

The GTM script’s `gtag` function is implemented as `gtag(...args) { dataLayer.push(args) }` (changed in https://github.com/nuxt/scripts/commit/9efc16f8ca90f14139d5634068a9ed04a62365c0), which enqueues a **plain `Array`**. The official pattern (mentioned in what feels like every other Google docs page around GTM integration^^) is `function gtag() { dataLayer.push(arguments) }` so each item is the **`Arguments`** object GTM expects when processing the events.

That mismatch shows up as Consent Mode looking “fine” in the console but incorrect/not working ([Analytics Debugger](https://chromewebstore.google.com/detail/analytics-debugger/ilnpmccnfdjdjjikgkefkcegefikecdc) showing **`(message)`** instead of **`consent → default` / `consent → update`**) or straight up not appearing (Tag Assistant **“Consent not configured”**).

See the following **before/after screenshot**: left is `@nuxt/scripts@1.0.6` with `(3) […]` rows; right is this branch with `Arguments(3) […]` and the debugger labelling consent correctly.

<img width="2096" height="1101" alt="image" src="https://github.com/user-attachments/assets/e332902f-1d69-4902-912b-961cc4124f39" />

**Change**

- In `packages/script/src/runtime/registry/google-tag-manager.ts`
  - **clientInit gtag function** – Stop pushing the spread array; use a variadic signature only for TypeScript, and `dataLayer.push(arguments)` so default consent and any call through that function match native gtag queue items.
  - **consent.update** – Stop pushing a literal `['consent','update', state]` array. Resolve the same dataLayer key as the registry (`options?.l ?? options?.dataLayer ?? 'dataLayer'`), ensure the array exists, then enqueue **`('consent','update', state)`** via the same **`push(arguments)`** pattern as the gtag function (so updates are **`Arguments`**, not a real `Array`).

**Tests**

- Extend `test/nuxt-runtime/consent-default.nuxt.test.ts` so GTM default-consent and `consent.update` assertions tolerate **`Arguments`** on `dataLayer` (normalize with `Array.from` where needed), including a check that the consent update row is **not** `Array.isArray`.

### Notes for reviewers / QA

- Discussion and history: [discussion #745](https://github.com/nuxt/scripts/discussions/745), regression [9efc16f](https://github.com/nuxt/scripts/commit/9efc16f8ca90f14139d5634068a9ed04a62365c0).
- Optional manual checks: Tag Assistant – **`gtm.uniqueEventId`** appears on rows GTM has fully processed; broken consent rows lack it.

Thanks a bunch to you for maintaining Nuxt Scripts.