### PR TITLE
fix(tiktokPixel): missing types

### DIFF
--- a/packages/script/src/runtime/registry/tiktok-pixel.ts
+++ b/packages/script/src/runtime/registry/tiktok-pixel.ts
@@ -13,11 +13,13 @@ type StandardEvents
     | 'AddPaymentInfo'
     | 'CompletePayment'
     | 'PlaceAnOrder'
+    | 'Purchase'
     | 'Contact'
     | 'Download'
     | 'SubmitForm'
     | 'CompleteRegistration'
     | 'Subscribe'
+    | 'StartTrial'
 
 interface EventProperties {
   content_id?: string
@@ -37,8 +39,14 @@ interface IdentifyProperties {
   external_id?: string
 }
 
+interface TrackOptions {
+  /** Used to deduplicate events sent from both the browser Pixel and the server-side Events API. */
+  event_id?: string
+  [key: string]: any
+}
+
 type TtqFns
-  = ((cmd: 'track', event: StandardEvents | (string & {}), properties?: EventProperties) => void)
+  = ((cmd: 'track', event: StandardEvents | (string & {}), properties?: EventProperties, options?: TrackOptions) => void)
     & ((cmd: 'page') => void)
     & ((cmd: 'identify', properties: IdentifyProperties) => void)
     & ((cmd: (string & {}), ...args: any[]) => void)

--- a/test/types/types.test-d.ts
+++ b/test/types/types.test-d.ts
@@ -1,6 +1,7 @@
 import type { ModuleOptions } from '../../packages/script/src/module'
 import type { CrispApi } from '../../packages/script/src/runtime/registry/crisp'
 import type { DefaultEventName } from '../../packages/script/src/runtime/registry/google-analytics'
+import type { TikTokPixelApi } from '../../packages/script/src/runtime/registry/tiktok-pixel'
 import type { NuxtConfigScriptRegistry, NuxtConfigScriptRegistryEntry, NuxtUseScriptOptions, RegistryScriptInput, ScriptRegistry, UseScriptContext } from '../../packages/script/src/runtime/types'
 import { describe, expectTypeOf, it } from 'vitest'
 
@@ -155,5 +156,22 @@ describe('#nuxt-scripts/types exports', () => {
     expectTypeOf<ScriptRegistry>().toHaveProperty('googleAnalytics')
     expectTypeOf<ScriptRegistry>().toHaveProperty('googleTagManager')
     expectTypeOf<ScriptRegistry>().toHaveProperty('clarity')
+  })
+})
+
+describe('tiktok pixel ttq', () => {
+  type Ttq = TikTokPixelApi['ttq']
+
+  it('track accepts the 4th options arg with event_id', () => {
+    expectTypeOf<Ttq>().toBeCallableWith('track', 'Purchase', { value: 10 }, { event_id: 'abc' })
+  })
+
+  it('track accepts standard events including Purchase and StartTrial', () => {
+    expectTypeOf<Ttq>().toBeCallableWith('track', 'Purchase')
+    expectTypeOf<Ttq>().toBeCallableWith('track', 'StartTrial')
+  })
+
+  it('track still accepts arbitrary custom event names', () => {
+    expectTypeOf<Ttq>().toBeCallableWith('track', 'CustomEvent')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #767

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The typed `ttq('track', ...)` overload didn't expose TikTok's optional 4th `options` arg, so users couldn't pass `event_id` for Pixel + Events API deduplication without casting. The `StandardEvents` union was also missing `Purchase` and `StartTrial`.

Adds the 4th `options` arg with `event_id` to the `track` overload and extends `StandardEvents`, preserving the `(string & {})` escape hatch for custom event names.

### ✅ Verification

- `pnpm test:types` — TikTok-related type tests pass (pre-existing posthog version-mismatch errors are unrelated).