### PR TITLE
docs(clarity): document env var name and call out common mistake

### DIFF
--- a/docs/content/scripts/clarity.md
+++ b/docs/content/scripts/clarity.md
@@ -54,3 +54,25 @@ consent.set({
 ```
 
 See [Clarity cookie consent](https://learn.microsoft.com/en-us/clarity/setup-and-installation/cookie-consent) for details.
+
+## With Environment Variables
+
+You can supply your Clarity project id with an environment variable. The env var name follows the registry key (`clarity`), not the marketing name:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  scripts: {
+    registry: {
+      clarity: { trigger: 'onNuxtReady' },
+    },
+  },
+})
+```
+
+```text [.env]
+NUXT_PUBLIC_SCRIPTS_CLARITY_ID=<YOUR_PROJECT_ID>
+```
+
+::warning
+The env var key must match the registry key. For Clarity that is `NUXT_PUBLIC_SCRIPTS_CLARITY_ID`, not `NUXT_PUBLIC_SCRIPTS_MICROSOFT_CLARITY_ID`.
+::


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #769

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The reporter set `NUXT_PUBLIC_SCRIPTS_MICROSOFT_CLARITY_ID=...` and expected it to populate `scripts.clarity.id`. That env var doesn't match any runtimeConfig path (`public.scripts.clarity.id` ↔ `NUXT_PUBLIC_SCRIPTS_CLARITY_ID`), so the id serialized as `""`. The auto env-default population added in #762 already reads the correct key for Clarity (`envDefaults: { id: '' }` in `registry.ts`), so no code change is needed; this is a docs/discoverability gap.

Adds an Environment Variables section to the Clarity docs (was missing, unlike Crisp / Intercom / GTM) and explicitly calls out that the env var follows the **registry key** (`clarity`), not the marketing name.