### PR TITLE
fix(plausible): honor scriptInput.src in bundle.resolve for self-hosted

### DIFF
--- a/packages/script/src/registry.ts
+++ b/packages/script/src/registry.ts
@@ -304,8 +304,8 @@ export async function registry(resolve?: (path: string) => Promise<string>): Pro
           // Self-hosted Plausible: when a custom `scriptInput.src` is provided,
           // bundle from that origin instead of the default plausible.io CDN.
           const userSrc = (options as any)?.scriptInput?.src
-          if (typeof userSrc === 'string' && userSrc.length > 0)
-            return userSrc
+          if (typeof userSrc === 'string' && userSrc.trim().length > 0)
+            return userSrc.trim()
           if (options?.scriptId)
             return `https://plausible.io/js/pa-${options.scriptId}.js`
           const extensions = Array.isArray(options?.extension) ? options.extension.join('.') : [options?.extension]

--- a/packages/script/src/registry.ts
+++ b/packages/script/src/registry.ts
@@ -301,6 +301,11 @@ export async function registry(resolve?: (path: string) => Promise<string>): Pro
       envDefaults: { domain: '' },
       bundle: {
         resolve: (options?: PlausibleAnalyticsInput) => {
+          // Self-hosted Plausible: when a custom `scriptInput.src` is provided,
+          // bundle from that origin instead of the default plausible.io CDN.
+          const userSrc = (options as any)?.scriptInput?.src
+          if (typeof userSrc === 'string' && userSrc.length > 0)
+            return userSrc
           if (options?.scriptId)
             return `https://plausible.io/js/pa-${options.scriptId}.js`
           const extensions = Array.isArray(options?.extension) ? options.extension.join('.') : [options?.extension]

--- a/test/unit/plausible-bundle-resolve.test.ts
+++ b/test/unit/plausible-bundle-resolve.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { getBundleResolve, registry } from '../../packages/script/src/registry'
+
+async function getPlausibleResolve() {
+  const all = await registry()
+  const script = all.find(s => s.registryKey === 'plausibleAnalytics')!
+  const resolve = getBundleResolve(script)
+  if (!resolve)
+    throw new Error('plausibleAnalytics bundle.resolve missing')
+  return resolve
+}
+
+describe('plausibleAnalytics bundle.resolve', () => {
+  it('returns default plausible.io URL with scriptId', async () => {
+    const resolve = await getPlausibleResolve()
+    expect(resolve({ scriptId: 'abc123' } as any)).toBe('https://plausible.io/js/pa-abc123.js')
+  })
+
+  it('returns default plausible.io URL with legacy extension', async () => {
+    const resolve = await getPlausibleResolve()
+    expect(resolve({ extension: 'hash' } as any)).toBe('https://plausible.io/js/script.hash.js')
+  })
+
+  it('returns default basic plausible.io URL with no options', async () => {
+    const resolve = await getPlausibleResolve()
+    expect(resolve(undefined)).toBe('https://plausible.io/js/script.js')
+  })
+
+  it('honors user-supplied scriptInput.src for self-hosted Plausible', async () => {
+    // Regression test for https://github.com/nuxt/scripts/issues/768
+    const resolve = await getPlausibleResolve()
+    const selfHosted = 'https://my-self-hosted-plausible.io/js/script.js'
+    expect(
+      resolve({ scriptId: 'abc123', scriptInput: { src: selfHosted } } as any),
+    ).toBe(selfHosted)
+    expect(
+      resolve({ scriptInput: { src: selfHosted } } as any),
+    ).toBe(selfHosted)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #768

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Self-hosted Plausible was broken in v1.0.6. The bundle transformer (`packages/script/src/plugins/transform.ts`) calls `bundle.resolve()` with the merged registry config to determine which URL to download at build time. Plausible's resolver only looked at `scriptId`/`extension`, always returning `plausible.io`, so:

- Self-hosted users hit `404` / `fetch failed` against `https://plausible.io/js/pa-<id>.js` during bundling.
- With `proxy: false`, the build error went away but the rewritten script still pointed at `plausible.io`, so the runtime `scriptInput.src` override never took effect.

Bundle resolver now honors `options.scriptInput?.src` first, so self-hosted Plausible bundles (and runs) against the user-configured origin.

### ✅ Verification

- [x] `pnpm vitest run --project unit test/unit/plausible-bundle-resolve.test.ts` (new regression test)
- [x] `pnpm vitest run --project unit` — 675 passed, 2 todo
- [ ] Manual: reproduction from issue (stackblitz `nuxt-starter-sapvn3tf`) builds without hitting `plausible.io`