### PR TITLE
refactor(tiktokPixel): use shared logger; fix docs passive voice

### DIFF
--- a/docs/content/scripts/tiktok-pixel.md
+++ b/docs/content/scripts/tiktok-pixel.md
@@ -114,7 +114,7 @@ proxy.ttq('track', 'Purchase', { value: 99 }, { test_event_code: 'TEST12345' })
 
 ## Advanced Matching
 
-TikTok requires identify fields (`email`, `phone_number`, `external_id`, `first_name`, `last_name`, `city`, `state`, `country`, `zip_code`) to be SHA-256-hashed lowercase. Raw values are silently ignored by TikTok; in development, Nuxt Scripts logs a warning when an unhashed value is detected:
+TikTok requires identify fields (`email`, `phone_number`, `external_id`, `first_name`, `last_name`, `city`, `state`, `country`, `zip_code`) to be SHA-256-hashed lowercase. TikTok silently drops raw values; in development, Nuxt Scripts logs a warning if it spots an unhashed value:
 
 ```ts
 import { sha256 } from 'ohash'

--- a/packages/script/src/runtime/registry/tiktok-pixel.ts
+++ b/packages/script/src/runtime/registry/tiktok-pixel.ts
@@ -1,5 +1,6 @@
 import type { RegistryScriptInput, UseScriptContext } from '#nuxt-scripts/types'
 import { withQuery } from 'ufo'
+import { logger } from '../logger'
 import { useRegistryScript } from '../utils'
 import { TikTokPixelOptions } from './schemas'
 
@@ -115,7 +116,7 @@ function warnUnhashedIdentify(props: Record<string, unknown>): void {
     return typeof v === 'string' && v.length > 0 && !SHA256_HEX.test(v)
   })
   if (offenders.length) {
-    console.warn(`[nuxt-scripts:tiktokPixel] identify() received unhashed value(s) for ${offenders.join(', ')}. TikTok requires SHA-256 hashing for advanced matching; raw values will be ignored. See https://business-api.tiktok.com/portal/docs?id=1739585702922241`)
+    logger.withTag('tiktokPixel').warn(`identify() received unhashed value(s) for ${offenders.join(', ')}. TikTok requires SHA-256 hashing for advanced matching; raw values will be ignored. See https://business-api.tiktok.com/portal/docs?id=1739585702922241`)
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #776.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Two cleanups against #776:

- **Use the project's shared `logger`** (`packages/script/src/runtime/logger.ts`) for the unhashed-PII warning in `identify()` instead of raw `console.warn`. Tags the message under `nuxt-scripts:tiktokPixel` so it matches every other registry warning.
- **Resolve the eslint passive-voice warning** on `docs/content/scripts/tiktok-pixel.md` (Advanced Matching section).

### ✅ Verification

- [x] `pnpm lint packages/script/src/runtime/registry/tiktok-pixel.ts docs/content/scripts/tiktok-pixel.md` — zero issues on the modified files.