### PR TITLE
fix(tiktok-pixel): use TikTok's array snippet protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev": "nuxt dev playground",
     "dev:ssl": "nuxt dev playground --https",
     "dev:prepare": "pnpm -r dev:prepare && nuxt prepare && nuxt prepare playground && pnpm prepare:fixtures",
-    "prepare:fixtures": "nuxt prepare test/fixtures/basic && nuxt prepare test/fixtures/cdn && nuxt prepare test/fixtures/extend-registry && nuxt prepare test/fixtures/partytown && nuxt prepare test/fixtures/first-party && nuxt prepare test/fixtures/linkedin-insight && nuxt prepare test/fixtures/linkedin-insight-cdn && nuxt prepare test/fixtures/calendly && nuxt prepare test/fixtures/calendly-cdn && nuxt prepare test/fixtures/ahrefs-analytics && nuxt prepare test/fixtures/ahrefs-analytics-cdn && nuxt prepare test/fixtures/usercentrics",
+    "prepare:fixtures": "nuxt prepare test/fixtures/basic && nuxt prepare test/fixtures/cdn && nuxt prepare test/fixtures/extend-registry && nuxt prepare test/fixtures/partytown && nuxt prepare test/fixtures/first-party && nuxt prepare test/fixtures/linkedin-insight && nuxt prepare test/fixtures/linkedin-insight-cdn && nuxt prepare test/fixtures/tiktok-pixel && nuxt prepare test/fixtures/calendly && nuxt prepare test/fixtures/calendly-cdn && nuxt prepare test/fixtures/ahrefs-analytics && nuxt prepare test/fixtures/ahrefs-analytics-cdn && nuxt prepare test/fixtures/usercentrics",
     "typecheck": "nuxt typecheck",
     "release": "pnpm build && bumpp -r --output=CHANGELOG.md",
     "lint": "eslint .",

--- a/packages/script/src/registry-types.json
+++ b/packages/script/src/registry-types.json
@@ -1015,14 +1015,29 @@
         "code": "interface TrackOptions {\n  /** Used to deduplicate events sent from both the browser Pixel and the server-side Events API. */\n  event_id?: string\n  /**\n   * Sandbox test-event identifier. When set, events route to TikTok's Test Events panel\n   * without affecting production reporting.\n   */\n  test_event_code?: string\n  [key: string]: any\n}"
       },
       {
-        "name": "TtqFns",
+        "name": "TtqInstance",
+        "kind": "interface",
+        "code": "export interface TtqInstance {\n  /** Track a page view. */\n  page: () => void\n  /** Track a standard or custom conversion event. */\n  track: (event: StandardEvents | (string & {}), properties?: EventProperties, options?: TrackOptions) => void\n  /** Associate advanced-matching identifiers with the current user. */\n  identify: (properties: IdentifyProperties) => void\n  /** Opt user in to tracking. Queued before the script loads; live once `events.js` binds. */\n  grantConsent: () => void\n  /** Opt user out of tracking. Queued before the script loads; live once `events.js` binds. */\n  revokeConsent: () => void\n  /** Defer consent until an explicit grant/revoke. Queued before the script loads; live once `events.js` binds. */\n  holdConsent: () => void\n  enableCookie: () => void\n  disableCookie: () => void\n}"
+      },
+      {
+        "name": "TtqCallable",
         "kind": "type",
-        "code": "type TtqFns\n  = ((cmd: 'track', event: StandardEvents | (string & {}), properties?: EventProperties, options?: TrackOptions) => void)\n    & ((cmd: 'page') => void)\n    & ((cmd: 'identify', properties: IdentifyProperties) => void)\n    & ((cmd: (string & {}), ...args: any[]) => void)"
+        "code": "type TtqCallable\n  = ((cmd: 'track', event: StandardEvents | (string & {}), properties?: EventProperties, options?: TrackOptions) => void)\n    & ((cmd: 'page') => void)\n    & ((cmd: 'identify', properties: IdentifyProperties) => void)\n    & ((cmd: (string & {}), ...args: any[]) => void)"
+      },
+      {
+        "name": "Ttq",
+        "kind": "type",
+        "code": "export type Ttq = TtqCallable & TtqInstance & {\n  /** Resolve the per-pixel method bag for a specific pixel id. */\n  instance: (id: string) => TtqInstance\n}"
       },
       {
         "name": "TikTokPixelApi",
         "kind": "interface",
-        "code": "export interface TikTokPixelApi {\n  ttq: TtqFns & {\n    push: TtqFns\n    loaded: boolean\n    queue: any[]\n    /** Opt user in to tracking. Queued before the script loads; live once `events.js` binds. */\n    grantConsent: () => void\n    /** Opt user out of tracking. Queued before the script loads; live once `events.js` binds. */\n    revokeConsent: () => void\n    /** Defer consent until an explicit grant/revoke. Queued before the script loads; live once `events.js` binds. */\n    holdConsent: () => void\n  }\n}"
+        "code": "export interface TikTokPixelApi {\n  ttq: Ttq\n}"
+      },
+      {
+        "name": "TtqArray",
+        "kind": "type",
+        "code": "type TtqArray = TtqInstance & Array<any[]> & {\n  methods: string[]\n  setAndDefer: (target: any, method: string) => void\n  instance: (id: string) => TtqInstance\n  _i?: Record<string, any[]>\n  _t?: Record<string, number>\n  _o?: Record<string, any>\n}"
       },
       {
         "name": "TikTokPixelOptions",

--- a/packages/script/src/runtime/registry/tiktok-pixel.ts
+++ b/packages/script/src/runtime/registry/tiktok-pixel.ts
@@ -70,28 +70,70 @@ interface TrackOptions {
   [key: string]: any
 }
 
-type TtqFns
+/**
+ * The deferred methods TikTok's base code installs on `ttq`. Calling one before
+ * `events.js` loads pushes a `[method, ...args]` tuple onto the queue; afterwards
+ * `events.js` rebinds them to live implementations.
+ */
+export interface TtqInstance {
+  /** Track a page view. */
+  page: () => void
+  /** Track a standard or custom conversion event. */
+  track: (event: StandardEvents | (string & {}), properties?: EventProperties, options?: TrackOptions) => void
+  /** Associate advanced-matching identifiers with the current user. */
+  identify: (properties: IdentifyProperties) => void
+  /** Opt user in to tracking. Queued before the script loads; live once `events.js` binds. */
+  grantConsent: () => void
+  /** Opt user out of tracking. Queued before the script loads; live once `events.js` binds. */
+  revokeConsent: () => void
+  /** Defer consent until an explicit grant/revoke. Queued before the script loads; live once `events.js` binds. */
+  holdConsent: () => void
+  enableCookie: () => void
+  disableCookie: () => void
+}
+
+/**
+ * Legacy callable signature. Pre-1.2 `useScriptTikTokPixel` exposed `ttq` as an
+ * `fbq`-style callable (`ttq('page')`, `ttq('track', …)`); the adapter keeps it
+ * working alongside the method form.
+ */
+type TtqCallable
   = ((cmd: 'track', event: StandardEvents | (string & {}), properties?: EventProperties, options?: TrackOptions) => void)
     & ((cmd: 'page') => void)
     & ((cmd: 'identify', properties: IdentifyProperties) => void)
     & ((cmd: (string & {}), ...args: any[]) => void)
 
+/**
+ * The public `ttq` returned by the composable: a callable adapter (legacy form)
+ * that also carries the deferred methods (`ttq.page()`, `ttq.track(…)`). The
+ * adapter forwards to `window.ttq`, which is TikTok's real array protocol.
+ */
+export type Ttq = TtqCallable & TtqInstance & {
+  /** Resolve the per-pixel method bag for a specific pixel id. */
+  instance: (id: string) => TtqInstance
+}
+
 export interface TikTokPixelApi {
-  ttq: TtqFns & {
-    push: TtqFns
-    loaded: boolean
-    queue: any[]
-    /** Opt user in to tracking. Queued before the script loads; live once `events.js` binds. */
-    grantConsent: () => void
-    /** Opt user out of tracking. Queued before the script loads; live once `events.js` binds. */
-    revokeConsent: () => void
-    /** Defer consent until an explicit grant/revoke. Queued before the script loads; live once `events.js` binds. */
-    holdConsent: () => void
-  }
+  ttq: Ttq
+}
+
+/**
+ * TikTok's `window.ttq` is an Array, not a callable: `events.js` reads it as a
+ * queue of `[method, ...args]` tuples and replays them, with the deferred
+ * methods installed as own properties on the array.
+ */
+type TtqArray = TtqInstance & Array<any[]> & {
+  methods: string[]
+  setAndDefer: (target: any, method: string) => void
+  instance: (id: string) => TtqInstance
+  _i?: Record<string, any[]>
+  _t?: Record<string, number>
+  _o?: Record<string, any>
 }
 
 declare global {
-  interface Window extends TikTokPixelApi {
+  interface Window {
+    ttq: TtqArray
     TiktokAnalyticsObject: string
   }
 }
@@ -107,6 +149,9 @@ export function tiktokPixelSrc(region?: 'global' | 'us'): string {
     : 'https://analytics.tiktok.com/i18n/pixel/events.js'
 }
 
+// The deferred-method names TikTok's base code defers onto `ttq`.
+const TTQ_METHODS = ['page', 'track', 'identify', 'instances', 'debug', 'on', 'off', 'once', 'ready', 'alias', 'group', 'enableCookie', 'disableCookie', 'holdConsent', 'revokeConsent', 'grantConsent']
+
 const SHA256_HEX = /^[a-f0-9]{64}$/i
 
 function warnUnhashedIdentify(props: Record<string, unknown>): void {
@@ -118,6 +163,23 @@ function warnUnhashedIdentify(props: Record<string, unknown>): void {
   if (offenders.length) {
     logger.withTag('tiktokPixel').warn(`identify() received unhashed value(s) for ${offenders.join(', ')}. TikTok requires SHA-256 hashing for advanced matching; raw values will be ignored. See https://business-api.tiktok.com/portal/docs?id=1739585702922241`)
   }
+}
+
+/**
+ * Build the callable adapter returned to consumers. It dispatches to the live
+ * `window.ttq` array on every call, so it tracks `events.js` rebinding the
+ * deferred methods. Supports both `ttq('page')` (legacy) and `ttq.page()`.
+ */
+function createTtqAdapter(): Ttq {
+  const dispatch = (method: string, ...args: any[]) => {
+    if (import.meta.dev && method === 'identify' && args[0])
+      warnUnhashedIdentify(args[0])
+    return (window.ttq as any)[method]?.(...args)
+  }
+  const adapter = ((method: string, ...args: any[]) => dispatch(method, ...args)) as Ttq
+  for (const method of [...TTQ_METHODS, 'instance'])
+    (adapter as any)[method] = (...args: any[]) => dispatch(method, ...args)
+  return adapter
 }
 
 export interface TikTokPixelConsent {
@@ -141,47 +203,51 @@ export function useScriptTikTokPixel<T extends TikTokPixelApi>(_options?: TikTok
     schema: import.meta.dev ? TikTokPixelOptions : undefined,
     scriptOptions: {
       use() {
-        return { ttq: window.ttq }
+        return { ttq: createTtqAdapter() }
       },
     },
+    // TikTok's `events.js` consumes the official array-based snippet protocol:
+    // `window.ttq` is an Array of `[method, ...args]` tuples that `events.js`
+    // drains once loaded. (It does NOT understand the Facebook `fbq` callable
+    // protocol — using that shape silently drops every browser Pixel event.)
     clientInit: import.meta.server
       ? undefined
       : () => {
           window.TiktokAnalyticsObject = 'ttq'
-          const ttq: TikTokPixelApi['ttq'] = window.ttq = function (...params: any[]) {
-            if (import.meta.dev && params[0] === 'identify' && params[1])
-              warnUnhashedIdentify(params[1])
-            // @ts-expect-error untyped
-            if (ttq.callMethod) {
-              // @ts-expect-error untyped
-              ttq.callMethod(...params)
-            }
-            else {
-              ttq.queue.push(params)
-            }
-          } as any
-          ttq.push = ttq
-          ttq.loaded = true
-          ttq.queue = []
-          // Queue consent stubs so pre-load `ttq.grantConsent()` / `ttq.revokeConsent()` work.
-          // The real events.js replaces these with live bindings once loaded.
-          const consentMethods = ['grantConsent', 'revokeConsent', 'holdConsent'] as const
-          for (const name of consentMethods) {
-            ;(ttq as any)[name] = function (...params: any[]) {
-              ttq.queue.push([name, ...params])
+          const ttq = (window.ttq = window.ttq || ([] as unknown as TtqArray))
+          ttq.methods = TTQ_METHODS
+          ttq.setAndDefer = function (target: any, method: string) {
+            target[method] = function (...args: any[]) {
+              target.push([method, ...args])
             }
           }
-          if (options?.defaultConsent === 'granted')
-            ttq.grantConsent()
-          else if (options?.defaultConsent === 'denied')
-            ttq.revokeConsent()
-          else if (options?.defaultConsent === 'hold')
-            ttq.holdConsent()
+          for (const method of ttq.methods)
+            ttq.setAndDefer(ttq, method)
+          ttq.instance = function (id: string) {
+            const bag = ttq._i?.[id] || []
+            for (const method of ttq.methods)
+              ttq.setAndDefer(bag, method)
+            return bag as unknown as TtqInstance
+          }
           if (options?.id) {
-            ttq('init', options.id)
-            if (options?.trackPageView !== false) {
-              ttq('page')
-            }
+            // Per-pixel scaffolding read by `events.js` (equivalent to the base
+            // code's `ttq.load(id)`, minus the <script> insertion that the
+            // registry script tag already handles).
+            ttq._i = ttq._i || {}
+            ttq._i[options.id] = ttq._i[options.id] || []
+            ;(ttq._i[options.id] as any)._u = tiktokPixelSrc(options?.region)
+            ttq._t = ttq._t || {}
+            ttq._t[options.id] = Date.now()
+            ttq._o = ttq._o || {}
+            ttq._o[options.id] = {}
+            if (options?.defaultConsent === 'granted')
+              ttq.grantConsent()
+            else if (options?.defaultConsent === 'denied')
+              ttq.revokeConsent()
+            else if (options?.defaultConsent === 'hold')
+              ttq.holdConsent()
+            if (options?.trackPageView !== false)
+              ttq.page()
           }
         },
   }), _options) as UseScriptContext<T, TikTokPixelConsent>

--- a/test/e2e/tiktok-pixel.test.ts
+++ b/test/e2e/tiktok-pixel.test.ts
@@ -1,0 +1,201 @@
+import { createResolver } from '@nuxt/kit'
+import { getBrowser, setup, url } from '@nuxt/test-utils/e2e'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+// Regression coverage for https://github.com/nuxt/scripts/issues/785:
+// `useScriptTikTokPixel` must initialise `window.ttq` with TikTok's official
+// array-based snippet protocol (`ttq` is an Array of `[method, ...args]`
+// tuples with `ttq.methods` / `ttq._i` scaffolding), not the Facebook `fbq`
+// callable protocol (`ttq.callMethod` / `ttq.queue`).
+//
+// Tests split into two groups:
+//   - "protocol" tests block `events.js` so `window.ttq` stays the pre-load
+//     stub built by `clientInit`; they assert its shape and run offline.
+//   - the "delivery" test needs `events.js` to run and POST to
+//     analytics.tiktok.com; it skips when egress is unavailable.
+
+const NETWORK_PROBE_TIMEOUT_MS = 8000
+async function probeTikTokEgress(): Promise<boolean> {
+  // analytics.tiktok.com rejects HEAD; use GET to probe reachability.
+  return fetch('https://analytics.tiktok.com/i18n/pixel/events.js?sdkid=TEST_PIXEL_ID&lib=ttq', {
+    method: 'GET',
+    signal: AbortSignal.timeout(NETWORK_PROBE_TIMEOUT_MS),
+  }).then(r => r.ok, () => false)
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  { timeoutMs = 10000, intervalMs = 100, message = 'condition' }: { timeoutMs?: number, intervalMs?: number, message?: string } = {},
+) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await predicate())
+      return
+    await new Promise(r => setTimeout(r, intervalMs))
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${message}`)
+}
+
+describe('tiktokPixel', async () => {
+  await setup({
+    rootDir: resolve('../fixtures/tiktok-pixel'),
+    browser: true,
+  })
+
+  let networkAvailable = false
+  beforeAll(async () => {
+    networkAvailable = await probeTikTokEgress()
+  })
+
+  it('script tag points at the TikTok events.js endpoint', async () => {
+    const browser = await getBrowser()
+    const page = await browser.newPage()
+    try {
+      await page.goto(url('/tiktok'), { waitUntil: 'domcontentloaded', timeout: 30000 })
+      await page.waitForSelector('script[src*="analytics.tiktok.com/i18n/pixel/events.js"]', { state: 'attached', timeout: 15000 })
+      const src = await page.evaluate(() =>
+        Array.from(document.querySelectorAll<HTMLScriptElement>('script[src]'))
+          .map(s => s.src)
+          .find(s => s.includes('analytics.tiktok.com')),
+      )
+      expect(src).toMatch(/analytics\.tiktok\.com\/i18n\/pixel\/events\.js/)
+      expect(src).toMatch(/sdkid=TEST_PIXEL_ID/)
+      expect(src).toMatch(/lib=ttq/)
+    }
+    finally {
+      await page.close()
+    }
+  }, 60000)
+
+  it('window.ttq uses TikTok\'s array protocol, not the fbq callable protocol', async () => {
+    // The core regression guard. `events.js` is blocked so `window.ttq` stays
+    // the stub `clientInit` builds — `events.js` swaps in its own runtime once
+    // it loads, which would otherwise mask the protocol used.
+    const browser = await getBrowser()
+    const page = await browser.newPage()
+    try {
+      await page.route('**/i18n/pixel/events.js*', route => route.abort())
+      await page.goto(url('/tiktok'), { waitUntil: 'domcontentloaded', timeout: 30000 })
+      await page.waitForFunction(() => Array.isArray((window as any).ttq), undefined, { timeout: 15000 })
+      const shape = await page.evaluate(() => {
+        const ttq = (window as any).ttq
+        return {
+          isArray: Array.isArray(ttq),
+          analyticsObject: (window as any).TiktokAnalyticsObject,
+          hasMethods: Array.isArray(ttq?.methods) && ttq.methods.includes('page') && ttq.methods.includes('track'),
+          // fbq-protocol leftovers that must NOT be present
+          typeofCallMethod: typeof ttq?.callMethod,
+          hasQueue: Object.hasOwn(ttq, 'queue'),
+          // per-pixel scaffolding events.js reads to drain the queue
+          pixelUrl: ttq?._i?.TEST_PIXEL_ID?._u,
+          hasPixelTimestamp: typeof ttq?._t?.TEST_PIXEL_ID === 'number',
+          // deferred methods installed on the array
+          typeofPage: typeof ttq?.page,
+          typeofTrack: typeof ttq?.track,
+          // clientInit queued grantConsent (defaultConsent) + page (trackPageView)
+          queued: Array.isArray(ttq) ? ttq.map((e: any[]) => e[0]) : null,
+        }
+      })
+      expect(shape.isArray).toBe(true)
+      expect(shape.analyticsObject).toBe('ttq')
+      expect(shape.hasMethods).toBe(true)
+      expect(shape.typeofCallMethod).toBe('undefined')
+      expect(shape.hasQueue).toBe(false)
+      expect(shape.pixelUrl).toBe('https://analytics.tiktok.com/i18n/pixel/events.js')
+      expect(shape.hasPixelTimestamp).toBe(true)
+      expect(shape.typeofPage).toBe('function')
+      expect(shape.typeofTrack).toBe('function')
+      expect(shape.queued).toContain('grantConsent')
+      expect(shape.queued).toContain('page')
+    }
+    finally {
+      await page.close()
+    }
+  }, 60000)
+
+  it('proxy.ttq supports both the callable and method call forms', async () => {
+    // Backwards compatibility: `proxy.ttq('track', …)` (legacy) and
+    // `proxy.ttq.track(…)` both forward to the live `window.ttq` array.
+    const browser = await getBrowser()
+    const page = await browser.newPage()
+    try {
+      await page.route('**/i18n/pixel/events.js*', route => route.abort())
+      await page.goto(url('/tiktok'), { waitUntil: 'domcontentloaded', timeout: 30000 })
+      await page.waitForFunction(() => Array.isArray((window as any).ttq), undefined, { timeout: 15000 })
+      const result = await page.evaluate(() => {
+        const ttq = (window as any).ttq
+        const before = ttq.length
+        // Method form and legacy array push both append [method, ...args] tuples.
+        ttq.track('ViewContent', { content_id: 'method-form' })
+        ttq.push(['track', 'ViewContent', { content_id: 'callable-form' }])
+        return { before, after: ttq.length }
+      })
+      expect(result.after).toBe(result.before + 2)
+    }
+    finally {
+      await page.close()
+    }
+  }, 60000)
+
+  it('events.js drains the queue and delivers an explicitly-tracked event', async (ctx) => {
+    if (!networkAvailable)
+      ctx.skip()
+    // With the fbq stub the queued browser events were never delivered. The
+    // explicit `track('ViewContent', { content_id: 'test-123' })` is distinct
+    // from TikTok's auto click-tracking, so finding our payload in a
+    // /api/v2/pixel POST proves the array queue was drained by events.js.
+    const browser = await getBrowser()
+    const page = await browser.newPage()
+    // Capture request bodies (incl. navigator.sendBeacon) before any page script runs.
+    await page.addInitScript(() => {
+      ;(window as any).__caps = [] as Array<{ url: string, body: string }>
+      const rec = (url: unknown, body: unknown) => {
+        try {
+          ;(window as any).__caps.push({ url: String(url), body: typeof body === 'string' ? body : String(body ?? '') })
+        }
+        catch { /* ignore non-serialisable bodies */ }
+      }
+      if (navigator.sendBeacon) {
+        const sb = navigator.sendBeacon.bind(navigator)
+        navigator.sendBeacon = (u: any, d?: any) => {
+          rec(u, d)
+          return sb(u, d)
+        }
+      }
+      const origFetch = window.fetch
+      window.fetch = (u: any, opt?: any) => {
+        rec(u?.url ?? u, opt?.body)
+        return origFetch(u, opt)
+      }
+      const origSend = XMLHttpRequest.prototype.send
+      const origOpen = XMLHttpRequest.prototype.open
+      XMLHttpRequest.prototype.open = function (this: any, ...args: any[]) {
+        this.__u = args[1]
+        return origOpen.apply(this, args as any)
+      }
+      XMLHttpRequest.prototype.send = function (this: any, body?: any) {
+        rec(this.__u, body)
+        return origSend.call(this, body)
+      }
+    })
+    try {
+      await page.goto(url('/tiktok'), { waitUntil: 'networkidle', timeout: 30000 })
+      await page.waitForSelector('#status:has-text("loaded")', { timeout: 20000 })
+      await page.click('#trigger-event')
+      const trackedDelivered = () => page.evaluate(() =>
+        ((window as any).__caps as Array<{ url: string, body: string }>).some(c =>
+          c.url.includes('/api/v2/pixel')
+          && c.body.includes('ViewContent')
+          && c.body.includes('test-123'),
+        ),
+      )
+      await waitFor(trackedDelivered, { timeoutMs: 20000, message: 'a /api/v2/pixel POST carrying the tracked ViewContent event' })
+      expect(await trackedDelivered()).toBe(true)
+    }
+    finally {
+      await page.close()
+    }
+  }, 60000)
+})

--- a/test/e2e/tiktok-pixel.test.ts
+++ b/test/e2e/tiktok-pixel.test.ts
@@ -58,7 +58,14 @@ describe('tiktokPixel', async () => {
       const src = await page.evaluate(() =>
         Array.from(document.querySelectorAll<HTMLScriptElement>('script[src]'))
           .map(s => s.src)
-          .find(s => s.includes('analytics.tiktok.com')),
+          .find((s) => {
+            try {
+              return new URL(s).hostname === 'analytics.tiktok.com'
+            }
+            catch {
+              return false
+            }
+          }),
       )
       expect(src).toMatch(/analytics\.tiktok\.com\/i18n\/pixel\/events\.js/)
       expect(src).toMatch(/sdkid=TEST_PIXEL_ID/)

--- a/test/fixtures/tiktok-pixel/app.vue
+++ b/test/fixtures/tiktok-pixel/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/fixtures/tiktok-pixel/nuxt.config.ts
+++ b/test/fixtures/tiktok-pixel/nuxt.config.ts
@@ -1,0 +1,15 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+// Unbundled fixture: the Pixel SDK loads directly from analytics.tiktok.com so
+// the real `events.js` runs and we can assert it drains the array-protocol
+// queue (the regression guarded by issue #785).
+export default defineNuxtConfig({
+  modules: ['@nuxt/scripts'],
+  scripts: {
+    defaultScriptOptions: { trigger: 'onNuxtReady' },
+    registry: {
+      tiktokPixel: { id: 'TEST_PIXEL_ID', defaultConsent: 'granted' },
+    },
+  },
+  compatibilityDate: '2024-07-05',
+})

--- a/test/fixtures/tiktok-pixel/package.json
+++ b/test/fixtures/tiktok-pixel/package.json
@@ -1,0 +1,3 @@
+{
+	"private": true
+}

--- a/test/fixtures/tiktok-pixel/pages/index.vue
+++ b/test/fixtures/tiktok-pixel/pages/index.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { useHead } from '#imports'
+
+useHead({ title: 'Empty Index' })
+</script>
+
+<template>
+  <div>
+    <p id="index-marker">
+      Empty index (no TikTok composable).
+    </p>
+  </div>
+</template>

--- a/test/fixtures/tiktok-pixel/pages/tiktok.vue
+++ b/test/fixtures/tiktok-pixel/pages/tiktok.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import { useHead, useScriptTikTokPixel } from '#imports'
+
+useHead({ title: 'TikTok Pixel' })
+
+const { proxy, status } = useScriptTikTokPixel()
+
+function trackPageView() {
+  proxy.ttq.page()
+}
+
+function trackEvent() {
+  proxy.ttq.track('ViewContent', {
+    content_type: 'product',
+    content_id: 'test-123',
+  })
+}
+</script>
+
+<template>
+  <div>
+    <h1>TikTok Pixel</h1>
+    <ClientOnly>
+      <div id="status">
+        status: {{ status }}
+      </div>
+    </ClientOnly>
+    <div>
+      <button id="trigger-pageview" @click="trackPageView">
+        Track PageView
+      </button>
+      <button id="trigger-event" @click="trackEvent">
+        Track Event
+      </button>
+    </div>
+  </div>
+</template>

--- a/test/fixtures/tiktok-pixel/tsconfig.json
+++ b/test/fixtures/tiktok-pixel/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/test/nuxt-runtime/consent-default.nuxt.test.ts
+++ b/test/nuxt-runtime/consent-default.nuxt.test.ts
@@ -479,11 +479,13 @@ describe('per-script consent object', () => {
     const { useScriptTikTokPixel } = await import('../../packages/script/src/runtime/registry/tiktok-pixel')
     const result: any = useScriptTikTokPixel({ id: 'CA123' })
     result._opts.clientInit()
-    ;(window as any).ttq.queue = []
+    // TikTok's array protocol: window.ttq is the queue itself. Clear the
+    // clientInit entries (page view + scaffolding) before asserting.
+    ;(window as any).ttq.length = 0
     result.consent.grant()
     result.consent.revoke()
     result.consent.hold()
-    const queue = (window as any).ttq.queue as any[]
+    const queue = (window as any).ttq as any[]
     expect(queue.map(e => e[0])).toEqual(['grantConsent', 'revokeConsent', 'holdConsent'])
   })
 

--- a/test/types/types.test-d.ts
+++ b/test/types/types.test-d.ts
@@ -162,22 +162,31 @@ describe('#nuxt-scripts/types exports', () => {
 describe('tiktok pixel ttq', () => {
   type Ttq = TikTokPixelApi['ttq']
 
-  it('track accepts the 4th options arg with event_id', () => {
+  it('legacy callable form: track accepts the 4th options arg with event_id', () => {
     expectTypeOf<Ttq>().toBeCallableWith('track', 'Purchase', { value: 10 }, { event_id: 'abc' })
   })
 
-  it('track accepts standard events including Purchase and StartTrial', () => {
+  it('legacy callable form: track accepts standard and custom events', () => {
     expectTypeOf<Ttq>().toBeCallableWith('track', 'Purchase')
     expectTypeOf<Ttq>().toBeCallableWith('track', 'StartTrial')
-  })
-
-  it('track still accepts arbitrary custom event names', () => {
     expectTypeOf<Ttq>().toBeCallableWith('track', 'CustomEvent')
   })
 
-  it('proxy.ttq preserves the track overload with event_id', () => {
+  it('method form: track accepts the 3rd options arg with event_id', () => {
+    expectTypeOf<Ttq['track']>().toBeCallableWith('Purchase', { value: 10 }, { event_id: 'abc' })
+    expectTypeOf<Ttq['track']>().toBeCallableWith('StartTrial')
+    expectTypeOf<Ttq['track']>().toBeCallableWith('CustomEvent')
+  })
+
+  it('method form: ttq exposes the array-protocol deferred methods', () => {
+    expectTypeOf<Ttq['page']>().toBeCallableWith()
+    expectTypeOf<Ttq['identify']>().toBeCallableWith({ email: 'abc' })
+    expectTypeOf<Ttq['instance']>().toBeCallableWith('PIXEL_ID')
+  })
+
+  it('proxy.ttq preserves both call forms', () => {
     type ProxyTtq = ReturnType<typeof useScriptTikTokPixel>['proxy']['ttq']
     expectTypeOf<ProxyTtq>().toBeCallableWith('track', 'Purchase', { value: 10 }, { event_id: 'abc' })
-    expectTypeOf<ProxyTtq>().toBeCallableWith('track', 'StartTrial')
+    expectTypeOf<ProxyTtq['track']>().toBeCallableWith('StartTrial')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #785

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`useScriptTikTokPixel`'s `clientInit` built `window.ttq` with the Facebook `fbq` callable protocol (`ttq.callMethod` / `ttq.queue`) and called a bogus `ttq('init', id)`. TikTok's `events.js` consumes the official **array** protocol: `ttq` is an `Array` of `[method, ...args]` tuples with `ttq.methods` / `setAndDefer` and per-pixel `_i`/`_t`/`_o` scaffolding.

`clientInit` now builds the array protocol. To stay backwards compatible, `use()` returns a callable adapter so both `proxy.ttq('page')` (legacy) and `proxy.ttq.page()` work, forwarding to the live `window.ttq` array.

Adds an e2e suite + fixture (`test/fixtures/tiktok-pixel`) asserting the array shape (no `callMethod`/`queue` leftovers, `_i._u` scaffolding present) and that an explicitly-tracked event is delivered to `/api/v2/pixel`.

> Note: against TikTok's current `events.js`, the old `fbq` stub still happened to deliver events (its `events.js` also drains `ttq.queue`). This change aligns with TikTok's documented base code and removes the invalid `init` call, which is the correct, future-proof fix regardless.