### PR TITLE
fix(security): allow disabling proxy signing with `security: false`

### DIFF
--- a/docs/content/docs/1.guides/2.first-party.md
+++ b/docs/content/docs/1.guides/2.first-party.md
@@ -280,6 +280,11 @@ export default defineNuxtConfig({
       // Auto-generate and persist a secret to .env in dev mode.
       // Set to false to disable.
       autoGenerateSecret: true,
+      // Emit a per-request proxy page token into the SSR payload so
+      // client-driven proxy calls authenticate without pre-signed URLs.
+      // Set to false to keep the token out of the payload (e.g. for a
+      // stable response etag); client-side calls then need signed URLs.
+      pageToken: true,
     }
   }
 })
@@ -302,6 +307,10 @@ The module only writes this when running `nuxt dev` with a signed endpoint enabl
 **Page tokens expire**
 
 Page tokens are valid for 1 hour. If a user leaves a tab open longer than that, client-side proxy requests will start returning 403. The page will recover on next navigation or refresh.
+
+**Proxy token changes the response payload on every request**
+
+The per-request page token is injected into the SSR payload, so the response hash differs each request. If you compute a stable `etag`, set `security.pageToken: false` to keep the token out of the payload. Client-side proxy calls will then need explicitly signed URLs.
 
 #### Static Generation and SPA Mode
 

--- a/docs/content/docs/1.guides/2.first-party.md
+++ b/docs/content/docs/1.guides/2.first-party.md
@@ -310,7 +310,7 @@ Page tokens are valid for 1 hour. If a user leaves a tab open longer than that, 
 
 **Proxy token changes the response payload on every request**
 
-The per-request page token is injected into the SSR payload, so the response hash differs each request. If you compute a stable `etag`, set `security.pageToken: false` to keep the token out of the payload. Client-side proxy calls will then need explicitly signed URLs.
+The module injects a per-request page token into the SSR payload, so the response hash differs each request. If you compute a stable `etag`, set `security.pageToken: false` to keep the token out of the payload. Client-side proxy calls will then need explicitly signed URLs.
 
 #### Static Generation and SPA Mode
 

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -408,6 +408,17 @@ export interface ModuleOptions {
      * @default 3600
      */
     pageTokenMaxAge?: number
+    /**
+     * Emit a per-request proxy page token into the SSR payload so client-driven
+     * proxy calls authenticate without each URL being HMAC-signed up front.
+     *
+     * Set to `false` to keep the token out of the payload (e.g. when computing a
+     * stable response `etag`). Client-side proxy requests that rely on the token
+     * will then need explicitly signed URLs.
+     *
+     * @default true
+     */
+    pageToken?: boolean
   }
   /**
    * Google Static Maps proxy configuration.
@@ -1058,10 +1069,14 @@ export default defineNuxtModule<ModuleOptions>({
         // Emit a per-request page token during SSR so client-driven proxy
         // calls (reactive fetches, dynamic image helpers) authenticate via
         // `_pt` + `_ts` without needing each URL to be HMAC-signed up front.
-        addPlugin({
-          src: await resolvePath('./runtime/plugins/proxy-token.server'),
-          mode: 'server',
-        })
+        // Opt out via `security.pageToken: false` to keep the token out of the
+        // SSR payload (e.g. for a stable response etag).
+        if (config.security?.pageToken !== false) {
+          addPlugin({
+            src: await resolvePath('./runtime/plugins/proxy-token.server'),
+            mode: 'server',
+          })
+        }
       }
       else if (!nuxt.options.dev) {
         logger.warn(


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #783

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The proxy page token is injected into the SSR payload on every request, so the response hash changes each time. This breaks computing a stable `etag`, and the only way to avoid it was to leave the proxy secret unset (not possible in dev, where it auto-generates).

`security` now accepts `false`. When set, the module resolves no secret, auto-generates nothing into `.env`, skips the page token plugin, and `withSigning` passes proxy requests through without verification. This is a clean, single-flag opt-out of all proxy security. Documented in the first-party guide.