### PR TITLE
fix(google-maps): deprecate heatmap component

### DIFF
--- a/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMapsHeatmapLayer.vue
+++ b/packages/script/src/runtime/components/GoogleMaps/ScriptGoogleMapsHeatmapLayer.vue
@@ -5,15 +5,46 @@ import { useGoogleMapsResource } from './useGoogleMapsResource'
 const props = defineProps<{
   /**
    * Configuration options for the heatmap layer visualization.
+   * @deprecated Google deprecated the Maps JavaScript API `HeatmapLayer` (May 2025) and removed it in v3.65 (May 2026). Consider [deck.gl HeatmapLayer](https://deck.gl/docs/api-reference/aggregation-layers/heatmap-layer) instead.
    * @see https://developers.google.com/maps/documentation/javascript/reference/visualization#HeatmapLayerOptions
    */
-  options?: Omit<google.maps.visualization.HeatmapLayerOptions, 'map'>
+  options?: Omit<HeatmapLayerOptions, 'map'>
 }>()
 
-const heatmapLayer = useGoogleMapsResource<google.maps.visualization.HeatmapLayer>({
+if (import.meta.dev) {
+  console.warn(
+    '[nuxt-scripts] <ScriptGoogleMapsHeatmapLayer> is deprecated. '
+    + 'Google deprecated the Maps JavaScript API HeatmapLayer (May 2025) and removed it in v3.65 (May 2026). '
+    + 'Consider deck.gl HeatmapLayer instead: https://deck.gl/docs/api-reference/aggregation-layers/heatmap-layer',
+  )
+}
+
+/**
+ * Configuration options for the heatmap layer visualization.
+ *
+ * The `HeatmapLayer` types were removed from `@types/google.maps` in v3.65 as part of Google's
+ * deprecation (the runtime feature is still available until May 2026), so we type the surface locally.
+ * @see https://developers.google.com/maps/documentation/javascript/reference/visualization#HeatmapLayerOptions
+ */
+interface HeatmapLayerOptions {
+  data?: unknown
+  dissipating?: boolean
+  gradient?: string[]
+  map?: google.maps.Map
+  maxIntensity?: number
+  opacity?: number
+  radius?: number
+}
+interface HeatmapLayer {
+  setMap: (map: google.maps.Map | null) => void
+  setOptions: (options: HeatmapLayerOptions) => void
+}
+
+const heatmapLayer = useGoogleMapsResource<HeatmapLayer>({
   async create({ mapsApi, map }) {
     await mapsApi.importLibrary('visualization')
-    return new mapsApi.visualization.HeatmapLayer({
+    const Layer = mapsApi.visualization.HeatmapLayer as unknown as new (opts: HeatmapLayerOptions) => HeatmapLayer
+    return new Layer({
       map,
       ...props.options,
     })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@types/google.maps` v3.65 stripped `HeatmapLayer` and `HeatmapLayerOptions` down to an empty stub as part of Google's deprecation (deprecated May 2025, runtime feature removed May 2026), which broke `nuxt typecheck` in `ScriptGoogleMapsHeatmapLayer.vue` (missing `HeatmapLayerOptions`, `setMap`, `setOptions`).

This types the heatmap layer surface locally so the component compiles again, and flags it as deprecated: a dev-only `console.warn` on use plus an `@deprecated` JSDoc on the `options` prop, both pointing to deck.gl HeatmapLayer as the alternative. The component still works at runtime for anyone pinned to an older Maps version.