### PR TITLE
fix: provide SpeedCurve snippet fallback

### DIFF
--- a/docs/content/scripts/speedcurve.md
+++ b/docs/content/scripts/speedcurve.md
@@ -22,7 +22,7 @@ The composable comes with the following defaults:
 
 ## Setup
 
-SpeedCurve LUX is opt-in. You **must** register it in `scripts.registry.speedcurve` before calling `useScriptSpeedCurve`, including for per-page usage. Registration triggers the module to resolve and inline the LUX primer at build time. Install the `@speedcurve/lux` peer dep alongside:
+SpeedCurve LUX is opt-in. Register it in `scripts.registry.speedcurve` to resolve and inline the LUX primer at build time. Install the `@speedcurve/lux` peer dep alongside:
 
 ```bash
 pnpm add -D @speedcurve/lux
@@ -52,7 +52,7 @@ export default defineNuxtConfig({
 })
 ```
 
-If `speedcurve` isn't registered, builds fail with an unresolved `#build/nuxt-scripts-speedcurve-snippet` import. If it's registered but `@speedcurve/lux` is missing, the build fails with an install hint. Pinning your own `@speedcurve/lux` version means you control when the primer snippet updates.
+If `speedcurve` isn't registered, `useScriptSpeedCurve` builds with an empty primer fallback. If it's registered but `@speedcurve/lux` is missing, the build fails with an install hint. Pinning your own `@speedcurve/lux` version means you control when the primer snippet updates.
 
 You can access the `LUX` object as a proxy directly, or await `$script` to get the loaded instance.
 

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -659,23 +659,24 @@ export default defineNuxtModule<ModuleOptions>({
       },
     })
 
-    // SpeedCurve requires opt-in via `scripts.registry.speedcurve` plus the
-    // `@speedcurve/lux` peer dep so the user controls the snippet version.
-    // Template only emitted on registration; non-registered consumers of
-    // useScriptSpeedCurve hit a build error from the unresolved virtual.
-    if (config.registry?.speedcurve) {
-      addTemplate({
-        filename: 'nuxt-scripts-speedcurve-snippet.mjs',
-        async getContents() {
-          const snippetPath = await resolvePath('@speedcurve/lux/dist/lux-snippet.js')
-          if (!existsSync(snippetPath)) {
-            throw new Error('[nuxt-scripts] useScriptSpeedCurve requires the @speedcurve/lux package. Install it with: npm i -D @speedcurve/lux')
-          }
-          const source = readFileSync(snippetPath, 'utf-8')
-          return `export const luxSnippetSource = ${JSON.stringify(source)}\n`
-        },
-      })
-    }
+    // SpeedCurve's runtime composable statically imports this virtual module.
+    // Emit an empty fallback unless `scripts.registry.speedcurve` is configured;
+    // registered users still control the primer version through @speedcurve/lux.
+    const speedcurveRegistered = !!config.registry?.speedcurve
+    addTemplate({
+      filename: 'nuxt-scripts-speedcurve-snippet.mjs',
+      async getContents() {
+        if (!speedcurveRegistered)
+          return 'export const luxSnippetSource = ""\n'
+
+        const snippetPath = await resolvePath('@speedcurve/lux/dist/lux-snippet.js')
+        if (!existsSync(snippetPath)) {
+          throw new Error('[nuxt-scripts] useScriptSpeedCurve requires the @speedcurve/lux package. Install it with: npm i -D @speedcurve/lux')
+        }
+        const source = readFileSync(snippetPath, 'utf-8')
+        return `export const luxSnippetSource = ${JSON.stringify(source)}\n`
+      },
+    })
 
     logger.debug('[nuxt-scripts] Proxy prefix:', proxyPrefix)
 

--- a/packages/script/src/runtime/registry/speedcurve.ts
+++ b/packages/script/src/runtime/registry/speedcurve.ts
@@ -49,6 +49,9 @@ export function useScriptSpeedCurve<T extends SpeedCurveApi>(_options?: SpeedCur
       trigger: 'client',
       use: () => ({ LUX: window.LUX! } as T),
       beforeInit: () => {
+        if (!luxSnippetSource)
+          return
+
         useHead({
           script: [{
             key: 'speedcurve-lux-primer',

--- a/test/fixtures/basic/pages/tpc/speedcurve-unregistered.vue
+++ b/test/fixtures/basic/pages/tpc/speedcurve-unregistered.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const { status } = useScriptSpeedCurve({ id: 'TEST_LUX_ID' })
+</script>
+
+<template>
+  <div>
+    <p id="status">
+      {{ status }}
+    </p>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

Fixes #810.

`useScriptSpeedCurve` can now be imported in apps that have not registered `scripts.registry.speedcurve` because the module always emits `#build/nuxt-scripts-speedcurve-snippet`. Unregistered apps get an empty primer fallback; registered apps still resolve `@speedcurve/lux` and keep the install hint if it is missing.

## Changes

- Emit the SpeedCurve snippet virtual module unconditionally, with an empty fallback when SpeedCurve is not registered.
- Skip primer injection when the generated snippet source is empty.
- Add a basic fixture page that uses `useScriptSpeedCurve` without registry config.
- Update the SpeedCurve setup docs to match the fallback behavior.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @nuxt/scripts dev:prepare`
- `pnpm exec nuxt prepare`
- `pnpm exec nuxt build test/fixtures/basic` (failed before the fix with unresolved `nuxt-scripts-speedcurve-snippet`; passes after)
- `pnpm exec vitest run --project unit test/unit/speedcurve-primer.test.ts test/unit/speedcurve-config.test.ts test/unit/speedcurve-auto-tracker.test.ts`
- `pnpm exec eslint packages/script/src/module.ts packages/script/src/runtime/registry/speedcurve.ts --max-warnings=0`

Verification gap: `pnpm exec nuxt build test/fixtures/speedcurve` reached client/server/Nitro build, then failed with a local macOS `ENAMETOOLONG` scanning Nitro output under this long workspace path.

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.
