### PR TITLE
fix(umami): prevent SSR crash by guarding window access in use()

### DIFF
--- a/packages/script/src/runtime/registry/umami-analytics.ts
+++ b/packages/script/src/runtime/registry/umami-analytics.ts
@@ -48,7 +48,10 @@ export function useScriptUmamiAnalytics<T extends UmamiAnalyticsApi>(_options?: 
       schema: import.meta.dev ? UmamiAnalyticsOptions : undefined,
       scriptOptions: {
         use() {
-          return window.umami
+          if (import.meta.client) {
+            return window.umami
+          }
+          return undefined
         },
       },
     }


### PR DESCRIPTION
Not very familiar with the codebase, but here goes, it fixed my problems after many hours of not finding useful logs :)

### 📚 Description

This PR fixes a fatal SSR crash (window is not defined) that occurs when using the Umami Analytics script registry in universal rendering mode.

Currently, the use() method in packages/script/src/runtime/registry/umami-analytics.ts eagerly attempts to return window.umami without an environment check. If this method is called within a component's setup phase, it crashes the Node.js/Nitro server during the initial render.

I simply added an import.meta.client guard to the use() method in the Umami registry.

During server-side execution, it now safely bypasses the window access, preventing the crash while preserving the expected behavior on the client.

