### PR TITLE
fix(runtime): avoid server-side script use callbacks

### DIFF
--- a/packages/script/src/runtime/composables/useScript.ts
+++ b/packages/script/src/runtime/composables/useScript.ts
@@ -162,6 +162,9 @@ export function resolveScriptKey(input: any): string {
 export function useScript<T extends Record<symbol | string, any> = Record<symbol | string, any>>(input: UseScriptInput, options?: NuxtUseScriptOptions<T>): UseScriptContext<UseFunctionType<NuxtUseScriptOptions<T>, T>> {
   input = typeof input === 'string' ? { src: input } : input
   options = defu(options, useNuxtScriptRuntimeConfig()?.defaultScriptOptions) as NuxtUseScriptOptions<T>
+  if (!import.meta.client && options.use) {
+    options.use = (() => undefined) as typeof options.use
+  }
 
   // Partytown quick-path: use useHead for SSR rendering
   // Partytown needs scripts in initial HTML with type="text/partytown"

--- a/packages/script/src/runtime/utils.ts
+++ b/packages/script/src/runtime/utils.ts
@@ -52,6 +52,13 @@ type OptionsFn<O> = (options: InferIfSchema<O>, ctx: { scriptInput?: UseScriptIn
   gcmConsent?: GcmConsentContract
 })
 
+function resolveClientUse(use?: NuxtUseScriptOptions['use']): NuxtUseScriptOptions['use'] | undefined {
+  if (!import.meta.client && use) {
+    return (() => undefined) as typeof use
+  }
+  return use
+}
+
 export function scriptRuntimeConfig<T extends RegistryScriptKey>(key: T): ScriptRegistry[T] {
   return ((useRuntimeConfig().public.scripts || {}) as ScriptRegistry)[key]
 }
@@ -79,7 +86,7 @@ export function useRegistryScript<T extends Record<string | symbol, any>, O = Em
   if (options.scriptMode === 'npm') {
     return createNpmScriptStub<T>({
       key: String(registryKey),
-      use: options.scriptOptions?.use,
+      use: resolveClientUse(options.scriptOptions?.use),
       clientInit: options.clientInit,
       trigger: userOptions.scriptOptions?.trigger as any,
     }) as any as UseScriptContext<UseFunctionType<NuxtUseScriptOptions<T>, T>>
@@ -112,6 +119,9 @@ export function useRegistryScript<T extends Record<string | symbol, any>, O = Em
 
   const scriptInput = defu(finalScriptInput as any, userOptions.scriptInput as any, { key: registryKey }) as any as UseScriptInput
   const scriptOptions = { ...userOptions?.scriptOptions, ...options.scriptOptions }
+  if (scriptOptions.use) {
+    scriptOptions.use = resolveClientUse(scriptOptions.use as NuxtUseScriptOptions['use']) as typeof scriptOptions.use
+  }
   if (import.meta.dev) {
     // Capture where the component was loaded from
     const error = new Error('Stack trace for component location')

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -23,6 +23,36 @@ describe('useRegistryScript scriptOptions', () => {
 
     expect(userScriptOptions).not.toHaveProperty('use')
   })
+
+  it('replaces registry use() with a server-safe noop outside client builds', () => {
+    const unsafeUse = vi.fn(() => {
+      throw new Error('use() should not run server-side')
+    })
+    const mockOptionsFunction = vi.fn((_opts, _ctx) => ({
+      scriptInput: { src: 'https://example.com/script.js' },
+      scriptOptions: { use: unsafeUse },
+    }))
+
+    const result = useRegistryScript('test', mockOptionsFunction, {})
+
+    expect(result.options.use()).toBeUndefined()
+    expect(unsafeUse).not.toHaveBeenCalled()
+  })
+
+  it('does not call npm-mode use() outside client builds', () => {
+    const unsafeUse = vi.fn(() => {
+      throw new Error('use() should not run server-side')
+    })
+    const mockOptionsFunction = vi.fn((_opts, _ctx) => ({
+      scriptMode: 'npm' as const,
+      scriptOptions: { use: unsafeUse },
+    }))
+
+    const result = useRegistryScript('test', mockOptionsFunction, {})
+
+    expect(result.proxy).toEqual({})
+    expect(unsafeUse).not.toHaveBeenCalled()
+  })
 })
 
 describe('useRegistryScript query param merging', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Related to #815

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`scriptOptions.use()` can read browser globals while Unhead builds script proxies. In SSR builds, `window` can be rewritten to `undefined`, so touching a registry proxy during server render can throw before hydration.

This wraps `use()` with a server-side noop in `useScript` and `useRegistryScript`, including npm-mode scripts. The client path still gets the original callback.