### PR TITLE
feat(proxy): support path aliases to hide third-party hostnames

### DIFF
--- a/FIRST_PARTY.md
+++ b/FIRST_PARTY.md
@@ -53,6 +53,22 @@ Some SDKs have quirks that require targeted regex patches after AST rewriting. T
 
 Note: Google Analytics previously needed `postProcess` regex patches for dynamically constructed collect URLs. This is no longer needed since the runtime intercept plugin catches all non-same-origin URLs at the `sendBeacon`/`fetch` call site.
 
+## Path aliases (`proxy.alias`)
+
+By default proxy paths embed the verbatim third-party hostname (`/_scripts/p/us.i.posthog.com/e/`), which leaks self-hosted/internal domains and is trivially classified by ad-blockers. `scripts.proxy.alias` replaces the hostname segment with an alias:
+- `true` — auto-generate a short deterministic hash per domain (`sha256(domain).slice(0,8)`)
+- `Record<domain, alias>` — explicit aliases; unlisted domains stay verbatim
+
+The pure logic lives in `proxy-alias.ts` (`aliasForDomain`, `buildDomainAliasMap`, `invertAliasMap`, `aliasProxyValue`). The module builds a `domain → alias` map from every proxied domain (those in `domainPrivacy`) and threads it through every point that emits a proxy path:
+- **Build-time rewrites** (`transform.ts`): `to: ${proxyPrefix}/${alias ?? domain}`
+- **Auto-inject** (`applyAutoInject`): `aliasProxyValue` rewrites the host segment of the computed endpoint
+- **Runtime intercept** (`intercept.ts`): embeds the alias map; `proxyUrl` maps `parsed.host → alias`
+- **Partytown** (`generatePartytownResolveUrl`): embeds the alias map; worker requests map `url.host → alias`
+- **Server handler** (`proxy-handler.ts`): the inverted `aliasToDomain` map resolves the alias segment back to the real domain before allowlist matching and forwarding (verbatim hostnames still resolve, so aliasing is non-breaking)
+- **Devtools** (`useScript.ts` network matcher): `aliasToDomain` is exposed in devtools config so aliased requests still attribute to their script
+
+Wildcard domains (`*`) are never aliased — they have no literal path form to rewrite and only exist for runtime allowlist matching.
+
 ## Key mapping
 
 Proxy config keys match registry keys directly — no indirection layer. A script's `registryKey` is used to look up its proxy config from `proxy-configs.ts`.

--- a/docs/content/docs/1.guides/2.first-party.md
+++ b/docs/content/docs/1.guides/2.first-party.md
@@ -183,6 +183,10 @@ Aliases apply everywhere a proxy path is produced: build-time URL rewrites, auto
 Aliases only change the path segment. To also change the `/_scripts/p` prefix itself, set the top-level `prefix` option (e.g. `prefix: '/_t'`).
 ::
 
+::callout{type="warning"}
+Aliases keep the real hostname out of request **URLs**, which is what ad-blockers and network observers match on. For scripts whose collection URL is built at runtime (e.g. a self-hosted endpoint passed via config), the real host can still appear in the client JavaScript, since the script needs to know where it would otherwise send. Aliasing does not obfuscate your bundle, it removes the hostname from the network-visible path.
+::
+
 ## Opting Out
 
 ### Per-Script

--- a/docs/content/docs/1.guides/2.first-party.md
+++ b/docs/content/docs/1.guides/2.first-party.md
@@ -144,6 +144,45 @@ export default defineNuxtConfig({
 })
 ```
 
+## Hiding Hostnames
+
+By default, proxied requests embed the real third-party hostname in the path, for example `/_scripts/p/us.i.posthog.com/e/`. For self-hosted services this leaks your internal domain (e.g. `/_scripts/p/analytics.internal.example.com/api/send`) into client-facing URLs, and the verbatim hostname makes requests easy for ad-blockers and network observers to classify.
+
+Use `proxy.alias` to replace hostnames with an alias in the path. The real domain never appears in the URL.
+
+Set `alias: true` to auto-generate a short opaque alias per domain:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  scripts: {
+    proxy: {
+      alias: true, // /_scripts/p/a1b2c3d4/e/
+    }
+  }
+})
+```
+
+Or map specific domains to custom aliases. Domains not listed keep their verbatim hostname:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  scripts: {
+    proxy: {
+      alias: {
+        'us.i.posthog.com': 'ph',
+        'analytics.internal.example.com': 'a',
+      }
+    }
+  }
+})
+```
+
+Aliases apply everywhere a proxy path is produced: build-time URL rewrites, auto-injected endpoints (such as PostHog's `apiHost`), runtime-intercepted requests, and Partytown worker requests. The server handler resolves the alias back to the real domain before forwarding upstream.
+
+::callout{type="info"}
+Aliases only change the path segment. To also change the `/_scripts/p` prefix itself, set the top-level `prefix` option (e.g. `prefix: '/_t'`).
+::
+
 ## Opting Out
 
 ### Per-Script

--- a/packages/script/src/devtools.ts
+++ b/packages/script/src/devtools.ts
@@ -129,6 +129,8 @@ export interface ProxyDevtoolsData {
   privacyMode: string
   scripts: ProxyDevtoolsScript[]
   totalDomains: number
+  /** Path alias → real domain, so devtools can attribute aliased proxy requests. */
+  aliasToDomain?: Record<string, string>
 }
 
 function computeDevtoolsPrivacyLevel(privacy: Record<string, boolean>): 'full' | 'partial' | 'none' {
@@ -178,6 +180,7 @@ export function buildDevtoolsData(
   proxyPrefix: string,
   privacyLabel: string,
   scripts: ProxyDevtoolsScript[],
+  aliasToDomain?: Record<string, string>,
 ): ProxyDevtoolsData {
   const allDomains = new Set<string>()
   for (const s of scripts) {
@@ -190,5 +193,6 @@ export function buildDevtoolsData(
     privacyMode: privacyLabel,
     scripts,
     totalDomains: allDomains.size,
+    aliasToDomain,
   }
 }

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -1,6 +1,7 @@
 import type { FetchOptions } from 'ofetch'
 import type { ProxyDevtoolsScript } from './devtools'
 import type { NormalizedRegistryEntry } from './normalize'
+import type { ProxyAliasConfig } from './proxy-alias'
 import type { ProxyPrivacyInput } from './runtime/server/utils/privacy'
 import type {
   FirstPartyPrivacy,
@@ -38,6 +39,7 @@ import { extractRequiredFields, migrateDeprecatedRegistryKeys, normalizeRegistry
 import { NuxtScriptsCheckScripts } from './plugins/check-scripts'
 import { generateInterceptPluginContents } from './plugins/intercept'
 import { NuxtScriptBundleTransformer } from './plugins/transform'
+import { aliasProxyValue, buildDomainAliasMap, invertAliasMap } from './proxy-alias'
 import { buildProxyConfigsFromRegistry, generatePartytownResolveUrl, getPartytownForwards, registry, resolveCapabilities } from './registry'
 import { registerTypeTemplates, templatePlugin, templateTriggerResolver } from './templates'
 import { validateScriptsEnvVars } from './validate-env'
@@ -215,6 +217,7 @@ export function applyAutoInject(
   proxyPrefix: string,
   registryKey: string,
   autoInject: ResolvedProxyAutoInject,
+  alias?: ProxyAliasConfig,
 ): void {
   if (isProxyDisabled(registryKey, registry, runtimeConfig))
     return
@@ -229,7 +232,7 @@ export function applyAutoInject(
   if (!config || config[autoInject.configField])
     return
 
-  const value = autoInject.computeValue(proxyPrefix, config)
+  const value = aliasProxyValue(autoInject.computeValue(proxyPrefix, config), proxyPrefix, alias)
   input[autoInject.configField] = value
 
   if (rtEntry && typeof rtEntry === 'object' && rtEntry !== input)
@@ -316,6 +319,23 @@ export interface ModuleOptions {
    * @default undefined (per-script defaults)
    */
   privacy?: FirstPartyPrivacy
+  /**
+   * First-party proxy behaviour.
+   */
+  proxy?: {
+    /**
+     * Replace third-party hostnames in proxy paths with aliases, so the real domain
+     * (e.g. a self-hosted analytics host) never appears in client-facing URLs.
+     *
+     * - `false` (default): paths embed the verbatim hostname (`/_scripts/p/us.i.posthog.com/...`)
+     * - `true`: auto-generate a short opaque alias per domain (`/_scripts/p/a1b2c3d4/...`)
+     * - `Record<domain, alias>`: explicit aliases (domain → alias); unlisted domains stay verbatim
+     *
+     * @default false
+     * @example { 'us.i.posthog.com': 'ph', 'analytics.internal.example.com': 'a' }
+     */
+    alias?: ProxyAliasConfig
+  }
   /**
    * The registry of supported third-party scripts. Presence enables infrastructure (proxy routes, types, bundling, composable auto-imports).
    * Scripts only auto-load globally when `trigger` is explicitly set in the config object.
@@ -853,6 +873,11 @@ export default defineNuxtModule<ModuleOptions>({
         }
       }
 
+      // Path alias config — maps real third-party domains to opaque/custom aliases so
+      // hostnames don't leak into client-facing proxy URLs. Shared with the transformer.
+      const proxyAlias = config.proxy?.alias
+      let domainAliases: Record<string, string> = {}
+
       // Finalize proxy setup: build configs, register intercept plugin, wire devtools
       if (anyNeedsProxy) {
         const builtConfigs = buildProxyConfigsFromRegistry(registryScripts, scriptByKey)
@@ -903,7 +928,7 @@ export default defineNuxtModule<ModuleOptions>({
           }
 
           if (proxyConfig.autoInject && config.registry)
-            applyAutoInject(config.registry, nuxt.options.runtimeConfig, proxyPrefix, key, proxyConfig.autoInject)
+            applyAutoInject(config.registry, nuxt.options.runtimeConfig, proxyPrefix, key, proxyConfig.autoInject, proxyAlias)
 
           if (nuxt.options.dev)
             devtoolsScripts.push(buildDevtoolsEntry(key, script, configKey, proxyConfig))
@@ -922,16 +947,25 @@ export default defineNuxtModule<ModuleOptions>({
           )
         }
 
+        // Build the domain → alias map from every proxied domain, then warn on any
+        // collision (two domains resolving to the same alias would mis-route at runtime).
+        domainAliases = buildDomainAliasMap(Object.keys(domainPrivacy), proxyAlias)
+        const aliasToDomain = invertAliasMap(domainAliases)
+        if (Object.keys(aliasToDomain).length !== Object.values(domainAliases).length) {
+          logger.warn('[nuxt-scripts] Proxy alias collision detected: multiple domains map to the same alias. Use unique aliases.')
+        }
+
         // Register intercept plugin
         addPluginTemplate({
           filename: 'nuxt-scripts-intercept.client.mjs',
-          getContents() { return generateInterceptPluginContents(proxyPrefix, { testMode: !!nuxt.options.test }) },
+          getContents() { return generateInterceptPluginContents(proxyPrefix, { testMode: !!nuxt.options.test, domainAliases }) },
         })
 
         // Server-side proxy config
         nuxt.options.runtimeConfig['nuxt-scripts-proxy'] = {
           proxyPrefix,
           domainPrivacy,
+          aliasToDomain,
           privacy: config.privacy,
         } as any
 
@@ -954,14 +988,14 @@ export default defineNuxtModule<ModuleOptions>({
 
         // Expose devtools data
         if (nuxt.options.dev) {
-          nuxt.options.runtimeConfig.public['nuxt-scripts-devtools'] = buildDevtoolsData(proxyPrefix, privacyLabel, devtoolsScripts) as any
+          nuxt.options.runtimeConfig.public['nuxt-scripts-devtools'] = buildDevtoolsData(proxyPrefix, privacyLabel, devtoolsScripts, aliasToDomain) as any
         }
 
         // Auto-configure Partytown resolveUrl for proxy
         if (partytownScripts.size && hasNuxtModule('@nuxtjs/partytown')) {
           const partytownConfig = (nuxt.options as any).partytown || {}
           if (!partytownConfig.resolveUrl) {
-            partytownConfig.resolveUrl = generatePartytownResolveUrl(proxyPrefix)
+            partytownConfig.resolveUrl = generatePartytownResolveUrl(proxyPrefix, domainAliases)
             ;(nuxt.options as any).partytown = partytownConfig
             logger.info('[partytown] Auto-configured resolveUrl for proxy')
           }
@@ -981,6 +1015,7 @@ export default defineNuxtModule<ModuleOptions>({
         registryConfig: nuxt.options.runtimeConfig.public.scripts as Record<string, any> | undefined,
         proxyConfigs,
         proxyPrefix,
+        domainAliases,
         partytownScripts,
         moduleDetected(module) {
           if (nuxt.options.dev && module !== '@nuxt/scripts' && !moduleInstallPromises.has(module) && !hasNuxtModule(module))

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -39,7 +39,7 @@ import { extractRequiredFields, migrateDeprecatedRegistryKeys, normalizeRegistry
 import { NuxtScriptsCheckScripts } from './plugins/check-scripts'
 import { generateInterceptPluginContents } from './plugins/intercept'
 import { NuxtScriptBundleTransformer } from './plugins/transform'
-import { aliasProxyValue, buildDomainAliasMap, invertAliasMap } from './proxy-alias'
+import { aliasProxyValue, buildDomainAliasMap, invertAliasMap, isSafeAliasSegment } from './proxy-alias'
 import { buildProxyConfigsFromRegistry, generatePartytownResolveUrl, getPartytownForwards, registry, resolveCapabilities } from './registry'
 import { registerTypeTemplates, templatePlugin, templateTriggerResolver } from './templates'
 import { validateScriptsEnvVars } from './validate-env'
@@ -950,21 +950,22 @@ export default defineNuxtModule<ModuleOptions>({
         // Build the domain → alias map from every proxied domain, then warn on any
         // collision (two domains resolving to the same alias would mis-route at runtime).
         domainAliases = buildDomainAliasMap(Object.keys(domainPrivacy), proxyAlias)
-        const aliasToDomain = invertAliasMap(domainAliases)
-        // Two domains sharing an alias would mis-route at runtime (one upstream wins).
-        // Fail the build rather than silently send one domain's traffic to the other.
-        if (Object.keys(aliasToDomain).length !== Object.values(domainAliases).length) {
-          const seen = new Map<string, string>()
-          const clashes: string[] = []
-          for (const [domain, alias] of Object.entries(domainAliases)) {
-            const prev = seen.get(alias)
-            if (prev)
-              clashes.push(`"${prev}" and "${domain}" → "${alias}"`)
-            else
-              seen.set(alias, domain)
-          }
-          throw new Error(`[nuxt-scripts] Proxy alias collision: ${clashes.join(', ')}. Give each domain a unique alias.`)
+        // Validate aliases at the build boundary so the runtime map is unambiguous:
+        // every alias must be a safe single path segment, unique, and must not equal a
+        // real proxied domain (else the verbatim-hostname fallback could pick the wrong one).
+        const realDomains = new Set(Object.keys(domainPrivacy))
+        const aliasOwner = new Map<string, string>()
+        for (const [domain, alias] of Object.entries(domainAliases)) {
+          if (!isSafeAliasSegment(alias))
+            throw new Error(`[nuxt-scripts] Invalid proxy alias "${alias}" for "${domain}": use a single URL-safe path segment (letters, digits, '-', '_', '.').`)
+          if (realDomains.has(alias))
+            throw new Error(`[nuxt-scripts] Proxy alias "${alias}" for "${domain}" collides with proxied domain "${alias}". Pick an alias that is not also a proxied hostname.`)
+          const prev = aliasOwner.get(alias)
+          if (prev)
+            throw new Error(`[nuxt-scripts] Proxy alias collision: "${prev}" and "${domain}" both map to "${alias}". Give each domain a unique alias.`)
+          aliasOwner.set(alias, domain)
         }
+        const aliasToDomain = invertAliasMap(domainAliases)
 
         // Register intercept plugin
         addPluginTemplate({

--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -951,8 +951,19 @@ export default defineNuxtModule<ModuleOptions>({
         // collision (two domains resolving to the same alias would mis-route at runtime).
         domainAliases = buildDomainAliasMap(Object.keys(domainPrivacy), proxyAlias)
         const aliasToDomain = invertAliasMap(domainAliases)
+        // Two domains sharing an alias would mis-route at runtime (one upstream wins).
+        // Fail the build rather than silently send one domain's traffic to the other.
         if (Object.keys(aliasToDomain).length !== Object.values(domainAliases).length) {
-          logger.warn('[nuxt-scripts] Proxy alias collision detected: multiple domains map to the same alias. Use unique aliases.')
+          const seen = new Map<string, string>()
+          const clashes: string[] = []
+          for (const [domain, alias] of Object.entries(domainAliases)) {
+            const prev = seen.get(alias)
+            if (prev)
+              clashes.push(`"${prev}" and "${domain}" → "${alias}"`)
+            else
+              seen.set(alias, domain)
+          }
+          throw new Error(`[nuxt-scripts] Proxy alias collision: ${clashes.join(', ')}. Give each domain a unique alias.`)
         }
 
         // Register intercept plugin

--- a/packages/script/src/plugins/intercept.ts
+++ b/packages/script/src/plugins/intercept.ts
@@ -4,16 +4,21 @@
  * that route matching URLs through the proxy. AST rewriting transforms
  * native API calls to use these wrappers at build time.
  *
- * Any non-same-origin URL is proxied through `proxyPrefix/<host><path>`.
+ * Any non-same-origin URL is proxied through `proxyPrefix/<host-or-alias><path>`.
  * No domain allowlist needed: only AST-rewritten third-party scripts call __nuxtScripts.
+ *
+ * `domainAliases` (real domain → path alias) is embedded so runtime-constructed URLs
+ * (e.g. self-hosted analytics endpoints) use the same opaque path segment as build-time
+ * rewrites, keeping hostnames out of client URLs.
  */
-export function generateInterceptPluginContents(proxyPrefix: string, options?: { testMode?: boolean }): string {
+export function generateInterceptPluginContents(proxyPrefix: string, options?: { testMode?: boolean, domainAliases?: Record<string, string> }): string {
   const testMode = options?.testMode ?? false
   return `export default defineNuxtPlugin({
   name: 'nuxt-scripts:intercept',
   enforce: 'pre',
   setup() {
     const proxyPrefix = ${JSON.stringify(proxyPrefix)};
+    const domainAliases = ${JSON.stringify(options?.domainAliases ?? {})};
     const origBeacon = typeof navigator !== 'undefined' && navigator.sendBeacon
       ? navigator.sendBeacon.bind(navigator)
       : () => false;
@@ -22,8 +27,10 @@ export function generateInterceptPluginContents(proxyPrefix: string, options?: {
     function proxyUrl(url) {
       try {
         const parsed = new URL(url, location.origin);
-        if (parsed.origin !== location.origin)
-          return location.origin + proxyPrefix + '/' + parsed.host + parsed.pathname + parsed.search;
+        if (parsed.origin !== location.origin) {
+          const seg = domainAliases[parsed.host] || parsed.host;
+          return location.origin + proxyPrefix + '/' + seg + parsed.pathname + parsed.search;
+        }
       } catch {}
       return url;
     }

--- a/packages/script/src/plugins/transform.ts
+++ b/packages/script/src/plugins/transform.ts
@@ -73,6 +73,8 @@ export interface AssetBundlerTransformerOptions {
    * Proxy prefix for first-party mode. Used to derive rewrite targets from domains.
    */
   proxyPrefix?: string
+  /** Map of real third-party domain → path alias, used to hide hostnames in proxy URLs. */
+  domainAliases?: Record<string, string>
   fallbackOnSrcOnBundleFail?: boolean
   fetchOptions?: FetchOptions
   cacheMaxAge?: number
@@ -469,7 +471,7 @@ export function NuxtScriptBundleTransformer(options: AssetBundlerTransformerOpti
                     // no literal form to rewrite at build time.
                     const proxyRewrites = proxyConfig?.domains?.filter(domain => !domain.includes('*')).map(domain => ({
                       from: domain,
-                      to: `${options.proxyPrefix}/${domain}`,
+                      to: `${options.proxyPrefix}/${options.domainAliases?.[domain] ?? domain}`,
                     }))
                     // Bundle-only SDK patches (independent of proxy). Used when bundling
                     // a script that needs neutralize-domain-check etc. but should keep

--- a/packages/script/src/proxy-alias.ts
+++ b/packages/script/src/proxy-alias.ts
@@ -12,6 +12,14 @@ import { createHash } from 'node:crypto'
 export type ProxyAliasConfig = boolean | Record<string, string> | undefined
 
 const WILDCARD_RE = /\*/
+// An alias is interpolated into `/_scripts/p/<alias>/...`, so it must be a single
+// URL path segment: no slash/query/hash/whitespace that would split or break the path.
+const SAFE_ALIAS_SEGMENT_RE = /^[\w.-]+$/
+
+/** Whether an explicit alias is a single URL-safe path segment. */
+export function isSafeAliasSegment(alias: string): boolean {
+  return SAFE_ALIAS_SEGMENT_RE.test(alias)
+}
 
 /**
  * Resolve the alias for a single third-party domain. Pure and deterministic so the

--- a/packages/script/src/proxy-alias.ts
+++ b/packages/script/src/proxy-alias.ts
@@ -24,9 +24,12 @@ export function aliasForDomain(domain: string, alias: ProxyAliasConfig): string 
   if (!alias || WILDCARD_RE.test(domain))
     return undefined
   if (alias === true)
-    // 8 hex chars (32 bits) — collision-free for the handful of domains a site proxies.
-    return createHash('sha256').update(domain).digest('hex').slice(0, 8)
-  return alias[domain] || undefined
+    // 12 hex chars (48 bits) — collision space large enough that auto-aliasing never
+    // silently misroutes; explicit-alias collisions are caught at build time instead.
+    return createHash('sha256').update(domain).digest('hex').slice(0, 12)
+  // Own-property guard so a domain literally named `toString`/`constructor` can't
+  // resolve to an inherited prototype member.
+  return Object.hasOwn(alias, domain) ? (alias[domain] || undefined) : undefined
 }
 
 /** Build a `domain → alias` map for the given proxied domains. */

--- a/packages/script/src/proxy-alias.ts
+++ b/packages/script/src/proxy-alias.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Proxy path alias configuration.
+ * - `false` / `undefined`: proxy paths use the verbatim third-party hostname
+ *   (`/_scripts/p/us.i.posthog.com/...`).
+ * - `true`: every proxied domain gets a short deterministic opaque alias
+ *   (`/_scripts/p/a1b2c3d4/...`), so the real hostname never appears in client URLs.
+ * - `Record<domain, alias>`: explicit aliases (domain → alias). Domains not listed
+ *   keep their verbatim hostname.
+ */
+export type ProxyAliasConfig = boolean | Record<string, string> | undefined
+
+const WILDCARD_RE = /\*/
+
+/**
+ * Resolve the alias for a single third-party domain. Pure and deterministic so the
+ * build-time rewrites and the runtime reverse map always agree without sharing state.
+ *
+ * Returns `undefined` when the domain should keep its verbatim hostname (no alias
+ * configured, or a wildcard pattern that has no literal path form to rewrite).
+ */
+export function aliasForDomain(domain: string, alias: ProxyAliasConfig): string | undefined {
+  if (!alias || WILDCARD_RE.test(domain))
+    return undefined
+  if (alias === true)
+    // 8 hex chars (32 bits) — collision-free for the handful of domains a site proxies.
+    return createHash('sha256').update(domain).digest('hex').slice(0, 8)
+  return alias[domain] || undefined
+}
+
+/** Build a `domain → alias` map for the given proxied domains. */
+export function buildDomainAliasMap(domains: Iterable<string>, alias: ProxyAliasConfig): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const domain of domains) {
+    const value = aliasForDomain(domain, alias)
+    if (value)
+      map[domain] = value
+  }
+  return map
+}
+
+/** Invert a `domain → alias` map into the `alias → domain` map the proxy handler resolves with. */
+export function invertAliasMap(map: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [domain, alias] of Object.entries(map))
+    out[alias] = domain
+  return out
+}
+
+/**
+ * Rewrite the leading `${proxyPrefix}/${host}` segment of a generated proxy path so the
+ * host is replaced with its alias. Used for auto-injected endpoint values (e.g. PostHog's
+ * `apiHost`) where the host is produced by an arbitrary `resolve` function.
+ */
+export function aliasProxyValue(value: string, proxyPrefix: string, alias: ProxyAliasConfig): string {
+  const prefix = `${proxyPrefix}/`
+  if (!alias || !value.startsWith(prefix))
+    return value
+  const rest = value.slice(prefix.length)
+  const host = rest.match(/^[^/?#]+/)?.[0]
+  if (!host)
+    return value
+  const aliased = aliasForDomain(host, alias)
+  return aliased ? `${prefix}${aliased}${rest.slice(host.length)}` : value
+}

--- a/packages/script/src/registry.ts
+++ b/packages/script/src/registry.ts
@@ -869,12 +869,17 @@ export async function registry(resolve?: (path: string) => Promise<string>): Pro
 /**
  * Generate a Partytown `resolveUrl` function string for proxy routing.
  * Partytown calls this for every network request made by worker-executed scripts.
- * Any non-same-origin URL is proxied through `proxyPrefix/<host><path>`.
+ * Any non-same-origin URL is proxied through `proxyPrefix/<host-or-alias><path>`.
+ *
+ * `domainAliases` (real domain → path alias) is embedded so worker requests use the
+ * same opaque path segment as build-time rewrites, keeping hostnames out of URLs.
  */
-export function generatePartytownResolveUrl(proxyPrefix: string): string {
+export function generatePartytownResolveUrl(proxyPrefix: string, domainAliases: Record<string, string> = {}): string {
   return `function(url, location, type) {
   if (url.origin !== location.origin) {
-    return new URL(${JSON.stringify(proxyPrefix)} + '/' + url.host + url.pathname + url.search, location.origin);
+    var aliases = ${JSON.stringify(domainAliases)};
+    var seg = aliases[url.host] || url.host;
+    return new URL(${JSON.stringify(proxyPrefix)} + '/' + seg + url.pathname + url.search, location.origin);
   }
 }`
 }

--- a/packages/script/src/runtime/composables/useScript.ts
+++ b/packages/script/src/runtime/composables/useScript.ts
@@ -46,6 +46,8 @@ function toNetworkRequest(entry: PerformanceResourceTiming, proxyPrefix: string)
 
 function createDomainMatcher(domains: Set<string>, proxyPrefix: string, scriptSrc: string | undefined) {
   const localHostname = window.location.hostname
+  // alias → real domain, so aliased proxy paths (/_scripts/p/<alias>/...) still attribute
+  const aliasToDomain = (useRuntimeConfig().public['nuxt-scripts-devtools'] as any)?.aliasToDomain || {}
   const scriptUrl = (() => {
     if (!scriptSrc)
       return ''
@@ -69,7 +71,8 @@ function createDomainMatcher(domains: Set<string>, proxyPrefix: string, scriptSr
       const proxyIdx = entryUrl.pathname.indexOf(proxyPath)
       if (proxyIdx !== -1) {
         const afterPrefix = entryUrl.pathname.slice(proxyIdx + proxyPath.length)
-        const proxyDomain = afterPrefix.split('/')[0]
+        const proxySegment = afterPrefix.split('/')[0]
+        const proxyDomain = proxySegment ? (aliasToDomain[proxySegment] || proxySegment) : undefined
         if (proxyDomain && domains.has(proxyDomain))
           return true
       }

--- a/packages/script/src/runtime/server/proxy-handler.ts
+++ b/packages/script/src/runtime/server/proxy-handler.ts
@@ -17,6 +17,8 @@ interface ProxyConfig {
   proxyPrefix: string
   /** Allowed domains with their privacy config */
   domainPrivacy: Record<string, ProxyPrivacyInput>
+  /** Reverse map of path alias → real third-party domain (when alias paths are enabled) */
+  aliasToDomain?: Record<string, string>
   /** Global user override — undefined means use per-script defaults */
   privacy?: ProxyPrivacyInput
   /** Enable verbose logging (default: only in dev) */
@@ -71,7 +73,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { proxyPrefix, domainPrivacy, privacy: globalPrivacy, debug = import.meta.dev } = proxyConfig
+  const { proxyPrefix, domainPrivacy, aliasToDomain, privacy: globalPrivacy, debug = import.meta.dev } = proxyConfig
   const path = event.path
   const log = debug
     ? (message: string, ...args: any[]) => {
@@ -80,11 +82,15 @@ export default defineEventHandler(async (event) => {
       }
     : () => {}
 
-  // Extract domain and remaining path from: /_scripts/p/<host>/<path>
+  // Extract domain and remaining path from: /_scripts/p/<host-or-alias>/<path>
   const afterPrefix = path.slice(proxyPrefix.length + 1) // +1 for the slash after prefix
   const slashIdx = afterPrefix.indexOf('/')
-  const domain = slashIdx > 0 ? afterPrefix.slice(0, slashIdx) : afterPrefix
+  const segment = slashIdx > 0 ? afterPrefix.slice(0, slashIdx) : afterPrefix
   const remainingPath = slashIdx > 0 ? afterPrefix.slice(slashIdx) : '/'
+
+  // Resolve path alias back to the real third-party domain. Falls back to the
+  // segment itself so verbatim-hostname paths keep working when aliasing is off.
+  const domain = aliasToDomain?.[segment] ?? segment
 
   if (!domain) {
     log('[proxy] No domain in path:', path)

--- a/packages/script/src/runtime/server/proxy-handler.ts
+++ b/packages/script/src/runtime/server/proxy-handler.ts
@@ -90,7 +90,9 @@ export default defineEventHandler(async (event) => {
 
   // Resolve path alias back to the real third-party domain. Falls back to the
   // segment itself so verbatim-hostname paths keep working when aliasing is off.
-  const domain = aliasToDomain?.[segment] ?? segment
+  // `Object.hasOwn` guard: a crafted segment like `toString`/`constructor` must not
+  // resolve to an inherited prototype member (which would break allowlist matching).
+  const domain = aliasToDomain && Object.hasOwn(aliasToDomain, segment) ? aliasToDomain[segment] : segment
 
   if (!domain) {
     log('[proxy] No domain in path:', path)

--- a/test/e2e/proxy-alias.test.ts
+++ b/test/e2e/proxy-alias.test.ts
@@ -1,0 +1,42 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup, url } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+// End-to-end coverage for proxy path aliases (#814). Builds a real app with
+// `scripts.proxy.alias` set and verifies the full module wiring: the alias reaches
+// both the auto-injected endpoint config and the runtime proxy handler.
+await setup({
+  rootDir: resolve('../fixtures/proxy-alias'),
+  build: true,
+})
+
+describe('proxy path aliases', () => {
+  it('auto-injects the aliased endpoint instead of the real hostname', async () => {
+    // app.vue renders the resolved Plausible endpoint from public runtime config.
+    const html = await $fetch('/')
+    expect(html).toContain('/_scripts/p/pl/api/event')
+    // the real hostname must never appear in the proxy path
+    expect(html).not.toContain('/_scripts/p/plausible.io')
+  })
+
+  it('rejects an unknown alias segment (reverse map is consulted)', async () => {
+    const res = await fetch(url('/_scripts/p/not-a-real-alias/api/event'))
+    expect(res.status).toBe(403)
+  })
+
+  it('resolves the alias back to the real domain instead of 403ing', async () => {
+    // `pl` resolves to plausible.io and is proxied upstream. Whatever the upstream
+    // returns (or a 502 if unreachable), it must not be our allowlist 403.
+    const res = await fetch(url('/_scripts/p/pl/api/event'), {
+      method: 'POST',
+      body: '{}',
+      headers: { 'content-type': 'application/json' },
+    }).catch(() => null)
+    // A null here means a transport-level error reaching our own server, which is a
+    // genuine test failure; a resolved alias always yields an HTTP response.
+    expect(res).not.toBeNull()
+    expect(res!.status).not.toBe(403)
+  }, 30000)
+})

--- a/test/fixtures/proxy-alias/.nuxtrc
+++ b/test/fixtures/proxy-alias/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@nuxt/test-utils="4.0.0"

--- a/test/fixtures/proxy-alias/app.vue
+++ b/test/fixtures/proxy-alias/app.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+// The module auto-injects Plausible's `endpoint` into public runtime config.
+// Render it so the e2e test can assert it was rewritten to the aliased path.
+const scripts = useRuntimeConfig().public.scripts as Record<string, any>
+const endpoint = scripts?.plausibleAnalytics?.endpoint ?? 'NO_ENDPOINT'
+</script>
+
+<template>
+  <div id="plausible-endpoint">{{ endpoint }}</div>
+</template>

--- a/test/fixtures/proxy-alias/nuxt.config.ts
+++ b/test/fixtures/proxy-alias/nuxt.config.ts
@@ -1,0 +1,33 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+// Minimal fixture for the proxy path alias feature (#814). Plausible is a clean
+// single-domain (plausible.io) proxied script with an `autoInject` endpoint, so we
+// can assert the alias is wired into both the injected config and the proxy handler.
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/scripts',
+  ],
+
+  // Explicit object here ensures the auto-injected `endpoint` lands in public
+  // runtime config (and is serialized to the client) so the test can read it.
+  runtimeConfig: {
+    public: {
+      scripts: {
+        plausibleAnalytics: { domain: 'example.com' },
+      },
+    },
+  },
+
+  scripts: {
+    registry: {
+      plausibleAnalytics: { domain: 'example.com' },
+    },
+    proxy: {
+      alias: {
+        'plausible.io': 'pl',
+      },
+    },
+  },
+
+  compatibilityDate: '2024-07-05',
+})

--- a/test/fixtures/proxy-alias/package.json
+++ b/test/fixtures/proxy-alias/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/test/unit/proxy-alias-generators.test.ts
+++ b/test/unit/proxy-alias-generators.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { generateInterceptPluginContents } from '../../packages/script/src/plugins/intercept'
+import { generatePartytownResolveUrl } from '../../packages/script/src/registry'
+
+const ALIASES = { 'us.i.posthog.com': 'ph' }
+
+describe('proxy alias - generated runtime code (#814)', () => {
+  describe('generatePartytownResolveUrl', () => {
+    it('rewrites a third-party host to its alias', () => {
+      // eslint-disable-next-line no-eval
+      const resolveUrl = eval(`(${generatePartytownResolveUrl('/_scripts/p', ALIASES)})`)
+      const out = resolveUrl(
+        new URL('https://us.i.posthog.com/e/?x=1'),
+        new URL('https://my-site.test/'),
+      )
+      expect(out.pathname).toBe('/_scripts/p/ph/e/')
+      expect(out.href).not.toContain('posthog')
+    })
+
+    it('falls back to the verbatim host when no alias is configured', () => {
+      // eslint-disable-next-line no-eval
+      const resolveUrl = eval(`(${generatePartytownResolveUrl('/_scripts/p')})`)
+      const out = resolveUrl(
+        new URL('https://eu.i.posthog.com/e/'),
+        new URL('https://my-site.test/'),
+      )
+      expect(out.pathname).toBe('/_scripts/p/eu.i.posthog.com/e/')
+    })
+  })
+
+  describe('generateInterceptPluginContents', () => {
+    it('embeds the alias map into the client intercept plugin', () => {
+      const code = generateInterceptPluginContents('/_scripts/p', { domainAliases: ALIASES })
+      expect(code).toContain('const domainAliases = {"us.i.posthog.com":"ph"}')
+      expect(code).toContain('domainAliases[parsed.host] || parsed.host')
+    })
+
+    it('defaults to an empty alias map', () => {
+      const code = generateInterceptPluginContents('/_scripts/p')
+      expect(code).toContain('const domainAliases = {}')
+    })
+  })
+})

--- a/test/unit/proxy-alias.test.ts
+++ b/test/unit/proxy-alias.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { aliasForDomain, aliasProxyValue, buildDomainAliasMap, invertAliasMap } from '../../packages/script/src/proxy-alias'
+
+describe('proxy-alias', () => {
+  describe('aliasForDomain', () => {
+    it('returns undefined when aliasing is disabled', () => {
+      expect(aliasForDomain('us.i.posthog.com', false)).toBeUndefined()
+      expect(aliasForDomain('us.i.posthog.com', undefined)).toBeUndefined()
+    })
+
+    it('auto-generates a short deterministic hash for true', () => {
+      const a = aliasForDomain('us.i.posthog.com', true)
+      const b = aliasForDomain('us.i.posthog.com', true)
+      expect(a).toBe(b)
+      expect(a).toMatch(/^[a-f0-9]{8}$/)
+      // hostname is never present verbatim
+      expect(a).not.toContain('posthog')
+    })
+
+    it('produces distinct aliases for distinct domains', () => {
+      expect(aliasForDomain('us.i.posthog.com', true)).not.toBe(aliasForDomain('eu.i.posthog.com', true))
+    })
+
+    it('uses an explicit alias when configured', () => {
+      expect(aliasForDomain('us.i.posthog.com', { 'us.i.posthog.com': 'ph' })).toBe('ph')
+    })
+
+    it('returns undefined for domains not in an explicit map', () => {
+      expect(aliasForDomain('eu.i.posthog.com', { 'us.i.posthog.com': 'ph' })).toBeUndefined()
+    })
+
+    it('skips wildcard domains (no literal path form)', () => {
+      expect(aliasForDomain('*.posthog.com', true)).toBeUndefined()
+    })
+  })
+
+  describe('buildDomainAliasMap', () => {
+    it('maps each domain to its alias', () => {
+      const map = buildDomainAliasMap(['us.i.posthog.com', 'eu.i.posthog.com'], { 'us.i.posthog.com': 'ph' })
+      expect(map).toEqual({ 'us.i.posthog.com': 'ph' })
+    })
+
+    it('auto-aliases every non-wildcard domain', () => {
+      const map = buildDomainAliasMap(['a.example.com', '*.example.com'], true)
+      expect(Object.keys(map)).toEqual(['a.example.com'])
+    })
+  })
+
+  describe('invertAliasMap', () => {
+    it('inverts domain → alias into alias → domain', () => {
+      expect(invertAliasMap({ 'us.i.posthog.com': 'ph' })).toEqual({ ph: 'us.i.posthog.com' })
+    })
+  })
+
+  describe('aliasProxyValue', () => {
+    const alias = { 'us.i.posthog.com': 'ph' }
+
+    it('rewrites the host segment of a proxy path', () => {
+      expect(aliasProxyValue('/_scripts/p/us.i.posthog.com', '/_scripts/p', alias)).toBe('/_scripts/p/ph')
+      expect(aliasProxyValue('/_scripts/p/us.i.posthog.com/e/?x=1', '/_scripts/p', alias)).toBe('/_scripts/p/ph/e/?x=1')
+    })
+
+    it('leaves unaliased domains untouched', () => {
+      expect(aliasProxyValue('/_scripts/p/eu.i.posthog.com/e', '/_scripts/p', alias)).toBe('/_scripts/p/eu.i.posthog.com/e')
+    })
+
+    it('is a no-op when aliasing is disabled or path is not a proxy path', () => {
+      expect(aliasProxyValue('/_scripts/p/us.i.posthog.com', '/_scripts/p', false)).toBe('/_scripts/p/us.i.posthog.com')
+      expect(aliasProxyValue('https://us.i.posthog.com', '/_scripts/p', alias)).toBe('https://us.i.posthog.com')
+    })
+  })
+})

--- a/test/unit/proxy-alias.test.ts
+++ b/test/unit/proxy-alias.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { aliasForDomain, aliasProxyValue, buildDomainAliasMap, invertAliasMap } from '../../packages/script/src/proxy-alias'
+import { aliasForDomain, aliasProxyValue, buildDomainAliasMap, invertAliasMap, isSafeAliasSegment } from '../../packages/script/src/proxy-alias'
 
 describe('proxy-alias', () => {
   describe('aliasForDomain', () => {
@@ -48,6 +48,23 @@ describe('proxy-alias', () => {
     it('auto-aliases every non-wildcard domain', () => {
       const map = buildDomainAliasMap(['a.example.com', '*.example.com'], true)
       expect(Object.keys(map)).toEqual(['a.example.com'])
+    })
+  })
+
+  describe('isSafeAliasSegment', () => {
+    it('accepts URL-safe single segments', () => {
+      expect(isSafeAliasSegment('ph')).toBe(true)
+      expect(isSafeAliasSegment('a1b2c3d4e5f6')).toBe(true)
+      expect(isSafeAliasSegment('my-alias_1.2')).toBe(true)
+    })
+
+    it('rejects segments with path/query/hash/whitespace characters', () => {
+      expect(isSafeAliasSegment('foo/bar')).toBe(false)
+      expect(isSafeAliasSegment('../etc')).toBe(false)
+      expect(isSafeAliasSegment('a?b')).toBe(false)
+      expect(isSafeAliasSegment('a#b')).toBe(false)
+      expect(isSafeAliasSegment('a b')).toBe(false)
+      expect(isSafeAliasSegment('')).toBe(false)
     })
   })
 

--- a/test/unit/proxy-alias.test.ts
+++ b/test/unit/proxy-alias.test.ts
@@ -12,9 +12,14 @@ describe('proxy-alias', () => {
       const a = aliasForDomain('us.i.posthog.com', true)
       const b = aliasForDomain('us.i.posthog.com', true)
       expect(a).toBe(b)
-      expect(a).toMatch(/^[a-f0-9]{8}$/)
+      expect(a).toMatch(/^[a-f0-9]{12}$/)
       // hostname is never present verbatim
       expect(a).not.toContain('posthog')
+    })
+
+    it('does not resolve inherited prototype members for an explicit map', () => {
+      expect(aliasForDomain('toString', { 'us.i.posthog.com': 'ph' })).toBeUndefined()
+      expect(aliasForDomain('constructor', { 'us.i.posthog.com': 'ph' })).toBeUndefined()
     })
 
     it('produces distinct aliases for distinct domains', () => {

--- a/test/unit/proxy-handler-alias.test.ts
+++ b/test/unit/proxy-handler-alias.test.ts
@@ -1,0 +1,98 @@
+import type { Server } from 'node:http'
+import { createServer } from 'node:http'
+import { createApp, toNodeListener } from 'h3'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Issue #814: proxy paths may use opaque/custom aliases instead of the verbatim
+ * third-party hostname. The handler must resolve `alias → real domain` before
+ * validating the allowlist and forwarding upstream.
+ */
+
+vi.mock('nitropack/runtime', () => ({
+  useRuntimeConfig: () => ({
+    'nuxt-scripts-proxy': {
+      proxyPrefix: '/_scripts/p',
+      domainPrivacy: {
+        'analytics.internal.example.com': false,
+      },
+      aliasToDomain: {
+        a1b2c3d4: 'analytics.internal.example.com',
+      },
+      privacy: false,
+      debug: false,
+    },
+  }),
+  useNitroApp: () => ({
+    hooks: { callHook: async () => {} },
+  }),
+}))
+
+describe('proxy handler - path aliases (#814)', () => {
+  let proxyServer: Server
+  let proxyPort: number
+  let upstreamServer: Server
+  let upstreamPort: number
+  let realFetch: typeof globalThis.fetch
+  let lastTargetUrl = ''
+
+  beforeAll(async () => {
+    upstreamServer = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end('{}')
+    })
+    await new Promise<void>(resolve => upstreamServer.listen(0, resolve))
+    upstreamPort = (upstreamServer.address() as any).port
+
+    realFetch = globalThis.fetch
+    globalThis.fetch = async (input: any, init?: any) => {
+      const reqUrl = typeof input === 'string' ? input : input.url
+      lastTargetUrl = reqUrl
+      const url = new URL(reqUrl)
+      if (url.hostname === 'analytics.internal.example.com') {
+        const redirected = `http://127.0.0.1:${upstreamPort}${url.pathname}${url.search}`
+        return realFetch(redirected, { ...init, headers: {} })
+      }
+      return realFetch(input, init)
+    }
+
+    const mod = await import('../../packages/script/src/runtime/server/proxy-handler')
+    const app = createApp()
+    app.use(mod.default)
+    proxyServer = createServer(toNodeListener(app))
+    await new Promise<void>(resolve => proxyServer.listen(0, resolve))
+    proxyPort = (proxyServer.address() as any).port
+  })
+
+  beforeEach(() => {
+    lastTargetUrl = ''
+  })
+
+  afterAll(() => {
+    if (realFetch)
+      globalThis.fetch = realFetch
+    upstreamServer?.close()
+    proxyServer?.close()
+  })
+
+  async function get(path: string) {
+    return realFetch(`http://127.0.0.1:${proxyPort}${path}`)
+  }
+
+  it('resolves an alias segment back to the real upstream domain', async () => {
+    const res = await get('/_scripts/p/a1b2c3d4/api/send?x=1')
+    expect(res.status).toBe(200)
+    expect(lastTargetUrl).toBe('https://analytics.internal.example.com/api/send?x=1')
+  })
+
+  it('still accepts verbatim-hostname paths (alias is opt-in per request)', async () => {
+    const res = await get('/_scripts/p/analytics.internal.example.com/api/send')
+    expect(res.status).toBe(200)
+    expect(lastTargetUrl).toBe('https://analytics.internal.example.com/api/send')
+  })
+
+  it('rejects an unknown alias segment that is not in the allowlist', async () => {
+    const res = await get('/_scripts/p/deadbeef/api/send')
+    expect(res.status).toBe(403)
+  })
+})

--- a/test/unit/proxy-handler-alias.test.ts
+++ b/test/unit/proxy-handler-alias.test.ts
@@ -95,4 +95,11 @@ describe('proxy handler - path aliases (#814)', () => {
     const res = await get('/_scripts/p/deadbeef/api/send')
     expect(res.status).toBe(403)
   })
+
+  it('rejects a crafted segment matching a prototype member (no 500)', async () => {
+    // `aliasToDomain['toString']` would be Object.prototype.toString without the
+    // own-property guard, breaking allowlist matching and 500-ing.
+    const res = await get('/_scripts/p/toString/api/send')
+    expect(res.status).toBe(403)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #814

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

First-party proxy paths embed the real third-party hostname verbatim, e.g. `/_scripts/p/us.i.posthog.com/e/`. For self-hosted services this leaks an internal domain (`/_scripts/p/analytics.internal.example.com/api/send`) into client-facing URLs, and the raw hostname is trivially classified by ad-blockers and network observers.

This adds `scripts.proxy.alias` to replace the hostname segment with an alias. Off by default, so existing paths are unchanged.

```ts
export default defineNuxtConfig({
  scripts: {
    proxy: {
      // auto-generate a short opaque alias per domain → /_scripts/p/a1b2c3d4/
      alias: true,
      // or map specific domains
      // alias: { 'us.i.posthog.com': 'ph', 'analytics.internal.example.com': 'a' },
    }
  }
})
```

The alias map is built from every proxied domain and threaded through every point that emits a proxy path: build-time URL rewrites (`transform.ts`), auto-injected endpoints like PostHog's `apiHost` (`applyAutoInject`), the runtime intercept plugin (`intercept.ts`, covers dynamically-constructed URLs such as self-hosted collection endpoints), and Partytown's `resolveUrl`. The server handler resolves the alias back to the real domain via an inverted map before allowlist matching and forwarding. Verbatim-hostname paths still resolve, so enabling aliasing is non-breaking. Wildcard allowlist domains are never aliased since they have no literal path form.

Core logic is isolated in a pure `proxy-alias.ts` module. Devtools network attribution resolves aliases back to domains so proxied requests still map to their script.

Tests: pure alias logic, generated intercept + Partytown code (executed), and end-to-end handler resolution (alias → domain, verbatim fallback, unknown-alias 403).