### PR TITLE
fix(snapchat): proxy bundled config loads

### DIFF
--- a/packages/script/src/plugins/rewrite-ast.ts
+++ b/packages/script/src/plugins/rewrite-ast.ts
@@ -219,7 +219,6 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
 
   const scriptLoaderUrlPatches = sdkPatches?.filter((p): p is Extract<SdkPatch, { type: 'replace-script-loader-url' }> =>
     p.type === 'replace-script-loader-url') ?? []
-  const scriptLoaderPathPrefixes = scriptLoaderUrlPatches.map(p => p.pathPrefix)
   const scriptLoaderFunctionKeys = new Set<string>()
 
   function isIdentifier(node: any, name?: string): boolean {
@@ -266,8 +265,8 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
     return `global:${name}`
   }
 
-  function isScriptLoaderPathLiteral(value: string): boolean {
-    return scriptLoaderPathPrefixes.some(prefix => value === prefix || value.startsWith(`${prefix}/`))
+  function isScriptLoaderPathLiteral(value: string, pathPrefix: string): boolean {
+    return value === pathPrefix || value.startsWith(`${pathPrefix}/`)
   }
 
   function getIdentifierInit(name: string): any | null {
@@ -286,7 +285,7 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
     return null
   }
 
-  function findScriptLoaderPathExpression(node: any, seenIdentifiers = new Set<string>()): any {
+  function findScriptLoaderPathExpression(node: any, pathPrefix: string, seenIdentifiers = new Set<string>()): any {
     if (!node)
       return null
     if (node.type === 'Identifier') {
@@ -296,32 +295,32 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
       if (!init)
         return null
       seenIdentifiers.add(node.name)
-      return findScriptLoaderPathExpression(init, seenIdentifiers) ? node : null
+      return findScriptLoaderPathExpression(init, pathPrefix, seenIdentifiers) ? node : null
     }
-    if (node.type === 'Literal' && typeof node.value === 'string' && isScriptLoaderPathLiteral(node.value))
+    if (node.type === 'Literal' && typeof node.value === 'string' && isScriptLoaderPathLiteral(node.value, pathPrefix))
       return node
     if (node.type === 'TemplateLiteral') {
       const hasConfigPrefix = node.quasis?.some((q: any) => {
         const value = q.value?.cooked ?? q.value?.raw
-        return typeof value === 'string' && isScriptLoaderPathLiteral(value)
+        return typeof value === 'string' && isScriptLoaderPathLiteral(value, pathPrefix)
       })
       return hasConfigPrefix ? node : null
     }
     if (node.type === 'CallExpression') {
       for (const arg of node.arguments ?? []) {
-        const found = findScriptLoaderPathExpression(arg, seenIdentifiers)
+        const found = findScriptLoaderPathExpression(arg, pathPrefix, seenIdentifiers)
         if (found)
           return found
       }
       return null
     }
     if (node.type === 'BinaryExpression' || node.type === 'LogicalExpression')
-      return findScriptLoaderPathExpression(node.right, seenIdentifiers) || findScriptLoaderPathExpression(node.left, seenIdentifiers)
+      return findScriptLoaderPathExpression(node.right, pathPrefix, seenIdentifiers) || findScriptLoaderPathExpression(node.left, pathPrefix, seenIdentifiers)
     if (node.type === 'ConditionalExpression')
-      return findScriptLoaderPathExpression(node.consequent, seenIdentifiers) || findScriptLoaderPathExpression(node.alternate, seenIdentifiers)
+      return findScriptLoaderPathExpression(node.consequent, pathPrefix, seenIdentifiers) || findScriptLoaderPathExpression(node.alternate, pathPrefix, seenIdentifiers)
     if (node.type === 'SequenceExpression') {
       for (let i = node.expressions.length - 1; i >= 0; i--) {
-        const found = findScriptLoaderPathExpression(node.expressions[i], seenIdentifiers)
+        const found = findScriptLoaderPathExpression(node.expressions[i], pathPrefix, seenIdentifiers)
         if (found)
           return found
       }
@@ -633,13 +632,18 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
         && (node as any).callee?.type === 'Identifier'
         && scriptLoaderFunctionKeys.has(declarationKey((node as any).callee.name))) {
         const urlArg = (node as any).arguments?.[0]
-        const pathNode = findScriptLoaderPathExpression(urlArg)
-        if (urlArg && pathNode) {
+        if (urlArg) {
           for (const patch of scriptLoaderUrlPatches) {
             const rewrite = rewrites.find(r => r.from === patch.fromDomain)
             if (!rewrite)
               continue
+            const pathNode = findScriptLoaderPathExpression(urlArg, patch.pathPrefix)
+            if (!pathNode)
+              continue
             s.overwrite(urlArg.start, urlArg.end, `${needsLeadingSpace(urlArg.start)}self.location.origin+"${rewrite.to}"+${sourceOf(pathNode)}`)
+            // The replaced range may contain literals the domain-rewrite pass
+            // would also edit — descending would produce conflicting overwrites.
+            this.skip()
             break
           }
         }

--- a/packages/script/src/plugins/rewrite-ast.ts
+++ b/packages/script/src/plugins/rewrite-ast.ts
@@ -208,10 +208,181 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
     return prev && WORD_OR_DOLLAR_RE.test(prev) ? ' ' : ''
   }
 
+  function sourceOf(node: any): string {
+    return content.slice(node.start, node.end)
+  }
+
   // Pass 1: collect all declarations
   const scopeTracker = new ScopeTracker({ preserveExitedScopes: true })
   const { program } = parseAndWalk(content, filename, { scopeTracker })
   scopeTracker.freeze()
+
+  const scriptLoaderUrlPatches = sdkPatches?.filter((p): p is Extract<SdkPatch, { type: 'replace-script-loader-url' }> =>
+    p.type === 'replace-script-loader-url') ?? []
+  const scriptLoaderPathPrefixes = scriptLoaderUrlPatches.map(p => p.pathPrefix)
+  const scriptLoaderFunctionKeys = new Set<string>()
+
+  function isIdentifier(node: any, name?: string): boolean {
+    return node?.type === 'Identifier' && (!name || node.name === name)
+  }
+
+  function propertyName(node: any): string | null {
+    if (!node)
+      return null
+    if (node.type === 'Identifier')
+      return node.name
+    if (node.type === 'Literal' && typeof node.value === 'string')
+      return node.value
+    return null
+  }
+
+  function firstParamName(node: any): string | null {
+    const param = node?.params?.[0]
+    return param?.type === 'Identifier' ? param.name : null
+  }
+
+  function functionName(node: any, parent: any): string | null {
+    if (node.type === 'FunctionDeclaration' && node.id?.type === 'Identifier')
+      return node.id.name
+    if ((node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression')
+      && parent?.type === 'VariableDeclarator'
+      && parent.id?.type === 'Identifier') {
+      return parent.id.name
+    }
+    if ((node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression')
+      && parent?.type === 'AssignmentExpression'
+      && parent.left?.type === 'Identifier') {
+      return parent.left.name
+    }
+    return null
+  }
+
+  function declarationKey(name: string): string {
+    const decl = scopeTracker.getDeclaration(name)
+    if (decl) {
+      const node = (decl as any).node
+      return `${decl.type}:${decl.scope}:${node?.start ?? decl.start}:${node?.end ?? decl.end}`
+    }
+    return `global:${name}`
+  }
+
+  function isScriptLoaderPathLiteral(value: string): boolean {
+    return scriptLoaderPathPrefixes.some(prefix => value === prefix || value.startsWith(`${prefix}/`))
+  }
+
+  function getIdentifierInit(name: string): any | null {
+    const decl = scopeTracker.getDeclaration(name)
+    if (!(decl instanceof ScopeTrackerVariable))
+      return null
+
+    const declarators = (decl.variableNode as any).declarations
+    if (!declarators)
+      return null
+
+    for (const declarator of declarators) {
+      if (declarator.id?.type === 'Identifier' && declarator.id.name === name)
+        return declarator.init ?? null
+    }
+    return null
+  }
+
+  function findScriptLoaderPathExpression(node: any, seenIdentifiers = new Set<string>()): any {
+    if (!node)
+      return null
+    if (node.type === 'Identifier') {
+      if (seenIdentifiers.has(node.name))
+        return null
+      const init = getIdentifierInit(node.name)
+      if (!init)
+        return null
+      seenIdentifiers.add(node.name)
+      return findScriptLoaderPathExpression(init, seenIdentifiers) ? node : null
+    }
+    if (node.type === 'Literal' && typeof node.value === 'string' && isScriptLoaderPathLiteral(node.value))
+      return node
+    if (node.type === 'TemplateLiteral') {
+      const hasConfigPrefix = node.quasis?.some((q: any) => {
+        const value = q.value?.cooked ?? q.value?.raw
+        return typeof value === 'string' && isScriptLoaderPathLiteral(value)
+      })
+      return hasConfigPrefix ? node : null
+    }
+    if (node.type === 'CallExpression') {
+      for (const arg of node.arguments ?? []) {
+        const found = findScriptLoaderPathExpression(arg, seenIdentifiers)
+        if (found)
+          return found
+      }
+      return null
+    }
+    if (node.type === 'BinaryExpression' || node.type === 'LogicalExpression')
+      return findScriptLoaderPathExpression(node.right, seenIdentifiers) || findScriptLoaderPathExpression(node.left, seenIdentifiers)
+    if (node.type === 'ConditionalExpression')
+      return findScriptLoaderPathExpression(node.consequent, seenIdentifiers) || findScriptLoaderPathExpression(node.alternate, seenIdentifiers)
+    if (node.type === 'SequenceExpression') {
+      for (let i = node.expressions.length - 1; i >= 0; i--) {
+        const found = findScriptLoaderPathExpression(node.expressions[i], seenIdentifiers)
+        if (found)
+          return found
+      }
+    }
+    return null
+  }
+
+  function isScriptLoaderFunction(node: any, urlParam: string): boolean {
+    let matches = false
+    walk(node.body, {
+      enter(child) {
+        if (child !== node.body
+          && (child.type === 'FunctionDeclaration' || child.type === 'FunctionExpression' || child.type === 'ArrowFunctionExpression')) {
+          this.skip()
+          return
+        }
+        if (child.type === 'CallExpression'
+          && child.callee?.type === 'Identifier'
+          && child.callee.name === 'importScripts'
+          && isIdentifier(child.arguments?.[0], urlParam)) {
+          matches = true
+        }
+        if (child.type === 'CallExpression'
+          && child.callee?.type === 'MemberExpression'
+          && propertyName(child.callee.property) === 'setAttribute'
+          && child.arguments?.[0]?.type === 'Literal'
+          && child.arguments[0].value === 'src'
+          && isIdentifier(child.arguments?.[1], urlParam)) {
+          matches = true
+        }
+        if (child.type === 'Property'
+          && propertyName(child.key) === 'src'
+          && isIdentifier(child.value, urlParam)) {
+          matches = true
+        }
+        if (child.type === 'AssignmentExpression'
+          && child.left?.type === 'MemberExpression'
+          && propertyName(child.left.property) === 'src'
+          && isIdentifier(child.right, urlParam)) {
+          matches = true
+        }
+      },
+    })
+    return matches
+  }
+
+  if (scriptLoaderUrlPatches.length) {
+    walk(program, {
+      scopeTracker,
+      enter(node, parent) {
+        if (node.type !== 'FunctionDeclaration' && node.type !== 'FunctionExpression' && node.type !== 'ArrowFunctionExpression')
+          return
+        const name = functionName(node, parent)
+        const param = firstParamName(node)
+        if (!name || !param)
+          return
+        if (isScriptLoaderFunction(node, param))
+          scriptLoaderFunctionKeys.add(declarationKey(name))
+      },
+    })
+  }
 
   // Pass 2: rewrite with scope resolution
   walk(program, {
@@ -429,6 +600,46 @@ export function rewriteScriptUrlsAST(content: string, filename: string, rewrites
             if (!rewrite)
               continue
             s.overwrite(node.start, node.end, `${needsLeadingSpace(node.start)}(self.location.origin+"${rewrite.to}")`)
+            break
+          }
+        }
+      }
+
+      // SDK patch: replace-new-url-host
+      // Matches `new URL(<expr>).host` / `.hostname` and replaces it with a
+      // known vendor host so bundled scripts do not detect self-hosting.
+      if (sdkPatches?.some(p => p.type === 'replace-new-url-host')
+        && node.type === 'MemberExpression'
+        && !(node as any).computed) {
+        const obj = (node as any).object
+        const prop = (node as any).property
+        if (prop?.type === 'Identifier' && (prop.name === 'host' || prop.name === 'hostname')
+          && obj?.type === 'NewExpression'
+          && obj.callee?.type === 'Identifier' && obj.callee.name === 'URL'
+          && obj.arguments?.length >= 1) {
+          const patch = sdkPatches.find(p => p.type === 'replace-new-url-host')
+          if (patch)
+            s.overwrite(node.start, node.end, `${needsLeadingSpace(node.start)}${JSON.stringify(patch.host)}`)
+        }
+      }
+
+      // SDK patch: replace-script-loader-url
+      // Some SDKs assemble script URLs from minified variables, then pass them
+      // into a tiny script loader helper. Match the stable behavior: a known
+      // path prefix reaches a function that uses its first parameter as a
+      // script `src` or `importScripts` URL.
+      if (scriptLoaderUrlPatches.length
+        && node.type === 'CallExpression'
+        && (node as any).callee?.type === 'Identifier'
+        && scriptLoaderFunctionKeys.has(declarationKey((node as any).callee.name))) {
+        const urlArg = (node as any).arguments?.[0]
+        const pathNode = findScriptLoaderPathExpression(urlArg)
+        if (urlArg && pathNode) {
+          for (const patch of scriptLoaderUrlPatches) {
+            const rewrite = rewrites.find(r => r.from === patch.fromDomain)
+            if (!rewrite)
+              continue
+            s.overwrite(urlArg.start, urlArg.end, `${needsLeadingSpace(urlArg.start)}self.location.origin+"${rewrite.to}"+${sourceOf(pathNode)}`)
             break
           }
         }

--- a/packages/script/src/registry.ts
+++ b/packages/script/src/registry.ts
@@ -519,10 +519,16 @@ export async function registry(resolve?: (path: string) => Promise<string>): Pro
       src: 'https://sc-static.net/scevent.min.js',
       category: 'ad',
       envDefaults: { id: '' },
-      bundle: true,
+      bundle: {
+        sdkPatches: [{ type: 'replace-new-url-host', host: 'sc-static.net' }],
+      },
       proxy: {
         domains: ['sc-static.net', 'tr.snapchat.com', 'pixel.tapad.com'],
         privacy: PRIVACY_FULL,
+        sdkPatches: [
+          { type: 'replace-new-url-host', host: 'sc-static.net' },
+          { type: 'replace-script-loader-url', fromDomain: 'tr.snapchat.com', pathPrefix: '/config' },
+        ],
       },
       partytown: { forwards: ['snaptr'] },
     }),

--- a/packages/script/src/runtime/types.ts
+++ b/packages/script/src/runtime/types.ts
@@ -470,6 +470,10 @@ export type SdkPatch
    * Replace `new URL(<expr>).host` / `.hostname` with a known vendor host.
    * Used by SDKs that detect self-hosting from their own script URL and switch
    * into a different endpoint mode when bundled.
+   *
+   * Applies to EVERY `new URL(...).host` / `.hostname` in the bundle, not just
+   * the self-src detection — only use it for SDKs that don't parse other URLs
+   * (e.g. referrers, click-throughs) with this pattern.
    */
     | { type: 'replace-new-url-host', host: string }
   /**
@@ -478,6 +482,11 @@ export type SdkPatch
    * minified variables before passing them to a script `src` helper or
    * `importScripts`, where ordinary string literal URL rewriting cannot see
    * the final host.
+   *
+   * The loader's whole first argument is replaced with
+   * `origin + proxyPath + <matched path expression>` — any parts of the
+   * argument outside the matched path expression (e.g. an appended query
+   * string) are dropped.
    */
     | { type: 'replace-script-loader-url', fromDomain: string, pathPrefix: string }
 

--- a/packages/script/src/runtime/types.ts
+++ b/packages/script/src/runtime/types.ts
@@ -466,6 +466,20 @@ export type SdkPatch
    * lands on a 404 instead of the proxy. This patch redirects it through the proxy.
    */
     | { type: 'replace-new-url-origin', fromDomain: string }
+  /**
+   * Replace `new URL(<expr>).host` / `.hostname` with a known vendor host.
+   * Used by SDKs that detect self-hosting from their own script URL and switch
+   * into a different endpoint mode when bundled.
+   */
+    | { type: 'replace-new-url-host', host: string }
+  /**
+   * Replace script loader calls that receive a known path prefix with the
+   * configured proxied domain. This covers SDKs that assemble URLs from
+   * minified variables before passing them to a script `src` helper or
+   * `importScripts`, where ordinary string literal URL rewriting cannot see
+   * the final host.
+   */
+    | { type: 'replace-script-loader-url', fromDomain: string, pathPrefix: string }
 
 /**
  * Partytown capability config. When present, the script can run in a

--- a/test/e2e-dev/first-party.test.ts
+++ b/test/e2e-dev/first-party.test.ts
@@ -563,8 +563,8 @@ describe('first-party privacy stripping', () => {
 
     it('bundled scripts contain rewritten collect URLs', async () => {
       // Check bundled scripts have proxy URLs
-      const cacheDir = join(fixtureDir, 'node_modules/.cache/nuxt/scripts/bundle-proxy')
-      expect(existsSync(cacheDir), `Bundle proxy cache dir should exist at ${cacheDir}`).toBe(true)
+      const cacheDir = join(fixtureDir, 'node_modules/.cache/nuxt/scripts/bundle-patched')
+      expect(existsSync(cacheDir), `Patched bundle cache dir should exist at ${cacheDir}`).toBe(true)
 
       const files = readdirSync(cacheDir).filter(f => f.endsWith('.js'))
       expect(files.length).toBeGreaterThan(0)
@@ -591,6 +591,7 @@ describe('first-party privacy stripping', () => {
       let serverOrigin = ''
       const proxyRequests: string[] = []
       const externalRequests: string[] = []
+      const sameOriginRequests: string[] = []
 
       page.on('request', (req) => {
         const reqUrl = req.url()
@@ -605,6 +606,9 @@ describe('first-party privacy stripping', () => {
         const parsed = new URL(reqUrl)
         if (parsed.pathname.startsWith('/_scripts/p/')) {
           proxyRequests.push(parsed.pathname)
+        }
+        else if (serverOrigin && reqUrl.startsWith(serverOrigin)) {
+          sameOriginRequests.push(parsed.pathname)
         }
         else if (serverOrigin && !reqUrl.startsWith(serverOrigin) && parsed.protocol.startsWith('http')) {
           externalRequests.push(reqUrl)
@@ -639,7 +643,7 @@ describe('first-party privacy stripping', () => {
 
       await page.close()
 
-      return { captures, rawCaptures, proxyRequests, externalRequests, preClickProxyCount, postClickProxyCount }
+      return { captures, rawCaptures, proxyRequests, externalRequests, sameOriginRequests, preClickProxyCount, postClickProxyCount }
     }
 
     /**
@@ -818,13 +822,17 @@ describe('first-party privacy stripping', () => {
     }, 30000)
 
     it('snapchatPixel', async () => {
-      const { captures, rawCaptures, proxyRequests, externalRequests, preClickProxyCount, postClickProxyCount } = await testProvider('snapchatPixel', '/snap', {
+      const { captures, rawCaptures, proxyRequests, externalRequests, sameOriginRequests, preClickProxyCount, postClickProxyCount } = await testProvider('snapchatPixel', '/snap', {
         clickSelectors: ['#trigger-pageview', '#trigger-event'],
       })
       await assertCaptures('snapchatPixel', captures, rawCaptures, proxyRequests, externalRequests, {
         proxyPrefix: '/_scripts/p/snap',
         domains: ['snapchat.com'],
       }, { pre: preClickProxyCount, post: postClickProxyCount })
+      expect(
+        sameOriginRequests.some(path => path.startsWith('/config/')),
+        `snapchatPixel: bundled SDK requested config from the app origin: ${JSON.stringify(sameOriginRequests.filter(path => path.startsWith('/config/')))}`,
+      ).toBe(false)
     }, 30000)
 
     it('clarity', async () => {
@@ -1111,7 +1119,7 @@ describe('first-party privacy stripping', () => {
    */
   describe('bundled script integrity', () => {
     it('all cached proxy-rewritten scripts are syntactically valid', async () => {
-      const cacheDir = join(fixtureDir, 'node_modules/.cache/nuxt/scripts/bundle-proxy')
+      const cacheDir = join(fixtureDir, 'node_modules/.cache/nuxt/scripts/bundle-patched')
       if (!existsSync(cacheDir))
         return // skip if no cached scripts
 

--- a/test/fixtures/first-party/nuxt.config.ts
+++ b/test/fixtures/first-party/nuxt.config.ts
@@ -1,8 +1,8 @@
 import { defineNuxtConfig } from 'nuxt/config'
 
 // trigger: 'manual' prevents the auto-generated plugin from loading all 18
-// scripts globally on every page. Pages that need the real SDK load provide an
-// explicit trigger in their composable call, keeping cross-provider noise low.
+// scripts globally on every page. Pages that need the real SDK should provide
+// an explicit trigger in their composable call, keeping cross-provider noise low.
 const manual = { trigger: 'manual' as const }
 
 export default defineNuxtConfig({

--- a/test/fixtures/first-party/nuxt.config.ts
+++ b/test/fixtures/first-party/nuxt.config.ts
@@ -1,8 +1,8 @@
 import { defineNuxtConfig } from 'nuxt/config'
 
 // trigger: 'manual' prevents the auto-generated plugin from loading all 18
-// scripts globally on every page. Each page's composable call then overrides
-// the trigger and loads only its own script, eliminating cross-provider noise.
+// scripts globally on every page. Pages that need the real SDK load provide an
+// explicit trigger in their composable call, keeping cross-provider noise low.
 const manual = { trigger: 'manual' as const }
 
 export default defineNuxtConfig({

--- a/test/fixtures/first-party/pages/snap.vue
+++ b/test/fixtures/first-party/pages/snap.vue
@@ -7,6 +7,10 @@ useHead({
 
 const { proxy, status } = useScriptSnapchatPixel({
   id: '2295cbcc-cb3f-4727-8c09-1133b742722c',
+  scriptOptions: {
+    bundle: 'force',
+    trigger: 'client',
+  },
 })
 
 function trackPageView() {

--- a/test/unit/bundle-sdk-patches.test.ts
+++ b/test/unit/bundle-sdk-patches.test.ts
@@ -9,6 +9,7 @@ import { hash } from 'ohash'
 import { hasProtocol } from 'ufo'
 import { describe, expect, it, vi } from 'vitest'
 import { NuxtScriptBundleTransformer } from '../../packages/script/src/plugins/transform'
+import { buildProxyConfigsFromRegistry, registry } from '../../packages/script/src/registry'
 
 vi.mock('ohash', async (og) => {
   const mod = await og<typeof import('ohash')>()
@@ -44,6 +45,13 @@ vi.mock('@nuxt/kit', async (og) => {
 
 vi.mocked(hasProtocol).mockImplementation(() => true)
 vi.mocked(hash).mockImplementation(() => 'fathom-script')
+
+let _proxyConfigs: ReturnType<typeof buildProxyConfigsFromRegistry> | undefined
+async function getProxyConfigs() {
+  if (!_proxyConfigs)
+    _proxyConfigs = buildProxyConfigsFromRegistry(await registry())
+  return _proxyConfigs
+}
 
 function mockUpstream(bytes: Buffer) {
   fetchMock.mockResolvedValueOnce({
@@ -152,6 +160,7 @@ describe('bundle-only sdkPatches integration', () => {
     mockUpstream(snapchatLike)
     vi.mocked(hash).mockImplementationOnce(() => 'snapchat-script')
     const renderedScript = new Map()
+    const proxyConfigs = await getProxyConfigs()
 
     await runTransform(
       `const instance = useScriptSnapchatPixel({ id: '2295cbcc-cb3f-4727-8c09-1133b742722c' }, { bundle: true })`,
@@ -169,13 +178,7 @@ describe('bundle-only sdkPatches integration', () => {
           },
         ] as any,
         proxyConfigs: {
-          snapchatPixel: {
-            domains: ['sc-static.net', 'tr.snapchat.com', 'pixel.tapad.com'],
-            sdkPatches: [
-              { type: 'replace-new-url-host', host: 'sc-static.net' },
-              { type: 'replace-script-loader-url', fromDomain: 'tr.snapchat.com', pathPrefix: '/config' },
-            ],
-          } as any,
+          snapchatPixel: proxyConfigs.snapchatPixel,
         },
         proxyPrefix: '/_scripts/p',
       },

--- a/test/unit/bundle-sdk-patches.test.ts
+++ b/test/unit/bundle-sdk-patches.test.ts
@@ -73,6 +73,13 @@ describe('bundle-only sdkPatches integration', () => {
     `(function(){var s=document.currentScript;var E=s.getAttribute("data-api")||new URL(s.src).origin+"/api/event";var _=s.getAttribute("data-error")||new URL(s.src).origin+"/api/error";})();`,
   )
 
+  // Mirrors Snapchat scevent.min.js config bootstrap. When bundled, `S`
+  // resolves to /_scripts/assets/... and `new URL(S).host` becomes the page
+  // host. The SDK then requests /config/... from the Nuxt app origin.
+  const snapchatLike = Buffer.from(
+    `(function(){var s="sc-static.net",v="https://",l="snapchat.com",S="/_scripts/assets/scevent.min.js";function qr(t){var e={src:t}}var xe=y((function(){return new URL(S).host}),s);function De(t,n,r,e){return void 0===n&&(n=4),e?v+e+t:r?v+xe+t:v+"tr"+(ce()?"-shadow":6===n?"6":"")+"."+l+t}function Ea(t){var i="/config/no/"+t+".js?v=3.59.0";$n(xe,"localhost")?qr(De(i)):C?Sa(t,a):qr(xe!==s?v+xe+i:De(i))}})();`,
+  )
+
   it('applies neutralize-domain-check to bundle-only scripts (no proxy)', async () => {
     mockUpstream(fathomLike)
     const renderedScript = new Map()
@@ -139,6 +146,48 @@ describe('bundle-only sdkPatches integration', () => {
     expect(content).toMatch(/\(self\.location\.origin\+"\/_scripts\/p\/analytics\.ahrefs\.com"\)\+"\/api\/error"/)
     // Original derivation is gone — no remaining `new URL(s.src).origin`.
     expect(content).not.toMatch(/new URL\(s\.src\)\.origin/)
+  })
+
+  it('applies snapchat config host patches to bundled proxy scripts', async () => {
+    mockUpstream(snapchatLike)
+    vi.mocked(hash).mockImplementationOnce(() => 'snapchat-script')
+    const renderedScript = new Map()
+
+    await runTransform(
+      `const instance = useScriptSnapchatPixel({ id: '2295cbcc-cb3f-4727-8c09-1133b742722c' }, { bundle: true })`,
+      {
+        renderedScript,
+        scripts: [
+          {
+            registryKey: 'snapchatPixel',
+            src: 'https://sc-static.net/scevent.min.js',
+            bundle: {
+              sdkPatches: [{ type: 'replace-new-url-host', host: 'sc-static.net' }],
+            },
+            proxy: 'snapchatPixel',
+            import: { name: 'useScriptSnapchatPixel', from: '' },
+          },
+        ] as any,
+        proxyConfigs: {
+          snapchatPixel: {
+            domains: ['sc-static.net', 'tr.snapchat.com', 'pixel.tapad.com'],
+            sdkPatches: [
+              { type: 'replace-new-url-host', host: 'sc-static.net' },
+              { type: 'replace-script-loader-url', fromDomain: 'tr.snapchat.com', pathPrefix: '/config' },
+            ],
+          } as any,
+        },
+        proxyPrefix: '/_scripts/p',
+      },
+    )
+
+    const stored = [...renderedScript.values()][0]
+    expect(stored, 'bundle was not stored').toBeDefined()
+    const content = (stored.content as Buffer).toString('utf-8')
+    expect(content).toContain('return "sc-static.net"')
+    expect(content).toContain('qr(self.location.origin+"/_scripts/p/tr.snapchat.com"+i)')
+    expect(content).not.toContain('new URL(S).host')
+    expect(content).not.toContain('v+xe+i:De(i)')
   })
 
   it('leaves bundles untouched when no patches are configured', async () => {

--- a/test/unit/rewrite-ast.test.ts
+++ b/test/unit/rewrite-ast.test.ts
@@ -241,6 +241,162 @@ describe('rewriteScriptUrlsAST', () => {
     })
   })
 
+  describe('snapchat SDK config host patching', () => {
+    async function getSnapchatConfig() {
+      const configs = await getProxyConfigs()
+      return configs.snapchatPixel
+    }
+
+    it('pins bundled script host detection to sc-static.net', () => {
+      const patches = [{ type: 'replace-new-url-host' as const, host: 'sc-static.net' }]
+      const code = 'var xe=y((function(){return new URL(S).host}),s);'
+      const result = rewriteScriptUrlsAST(code, 'scevent.min.js', [], patches)
+      expect(result).toContain('return "sc-static.net"')
+      expect(result).not.toContain('new URL(S).host')
+    })
+
+    it('rewrites the self-hosted config loader branch to the proxy path', async () => {
+      const snapchatConfig = await getSnapchatConfig()
+      const snapchatRewrites = deriveRewrites(snapchatConfig.domains, '/_scripts/p')
+      const code = [
+        'function qr(t){var e={src:t};}',
+        'var xe=y((function(){return new URL(S).host}),s);',
+        'function De(t,n,r,e){return void 0===n&&(n=4),e?v+e+t:r?v+xe+t:v+"tr"+"."+l+t}',
+        'var i="/config/no/id.js?v=3.59.0";',
+        'qr(xe!==s?v+xe+i:De(i));',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'scevent.min.js', snapchatRewrites, snapchatConfig.sdkPatches)
+      expect(result).toContain('return "sc-static.net"')
+      expect(result).toContain('qr(self.location.origin+"/_scripts/p/tr.snapchat.com"+i);')
+      expect(result).not.toContain('v+xe+i:De(i)')
+    })
+
+    it('rewrites the nested production config loader branch to the proxy path', async () => {
+      const snapchatConfig = await getSnapchatConfig()
+      const snapchatRewrites = deriveRewrites(snapchatConfig.domains, '/_scripts/p')
+      const code = [
+        'function qr(t){var e={src:t};}',
+        'var xe=y((function(){return new URL(S).host}),s);',
+        'function De(t,n,r,e){return void 0===n&&(n=4),e?v+e+t:r?v+xe+t:v+"tr"+(ce()?"-shadow":6===n?"6":"")+"."+l+t}',
+        'var pa="/config",r=pa+"/"+n+"/"+t,i=r+".js"+e,a=r+".json"+e;',
+        '$n(xe,"localhost")?qr(De(i)):C?Sa(t,a):qr(xe!==s?v+xe+i:De(i));',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'scevent.min.js', snapchatRewrites, snapchatConfig.sdkPatches)
+      expect(result).toContain('return "sc-static.net"')
+      expect(result).toContain('qr(self.location.origin+"/_scripts/p/tr.snapchat.com"+i);')
+      expect(result).not.toContain('xe!==s?v+xe+i:De(i)')
+    })
+
+    it('does not depend on Snapchat minified variable or loader names', async () => {
+      const snapchatConfig = await getSnapchatConfig()
+      const snapchatRewrites = deriveRewrites(snapchatConfig.domains, '/_scripts/p')
+      const code = [
+        'function loadScript(url){importScripts(url);}',
+        'var scriptHost=y((function(){return new URL(stackUrl).hostname}),fallbackHost);',
+        'function makeUrl(path,mode,useDetected,override){return override?proto+override+path:useDetected?proto+scriptHost+path:proto+"tr"+"."+snapDomain+path}',
+        'var base="/config",path=base+"/"+tld+"/"+pixel,jsPath=path+".js"+version;',
+        'loadScript(scriptHost!==fallbackHost?proto+scriptHost+jsPath:makeUrl(jsPath));',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'scevent.min.js', snapchatRewrites, snapchatConfig.sdkPatches)
+      expect(result).toContain('return "sc-static.net"')
+      expect(result).toContain('loadScript(self.location.origin+"/_scripts/p/tr.snapchat.com"+jsPath);')
+      expect(result).not.toContain('scriptHost!==fallbackHost?proto+scriptHost+jsPath:makeUrl(jsPath)')
+    })
+  })
+
+  describe('generic script-loader URL patching', () => {
+    it('rewrites obfuscated script loader URLs by configured path prefix', () => {
+      const patches = [
+        { type: 'replace-script-loader-url' as const, fromDomain: 'config.example.com', pathPrefix: '/settings' },
+      ]
+      const configRewrites = deriveRewrites(['config.example.com'], '/_scripts/p')
+      const code = [
+        'function load(u){var s=document.createElement("script");s.src=u;}',
+        'var base="/settings",path=base+"/"+tenant+"/"+id+".js";',
+        'load(host!==cdn?proto+host+path:buildVendorUrl(path));',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
+      expect(result).toContain('load(self.location.origin+"/_scripts/p/config.example.com"+path);')
+      expect(result).not.toContain('host!==cdn?proto+host+path:buildVendorUrl(path)')
+    })
+
+    it('does not rewrite matching path variables passed to non-loader functions', () => {
+      const patches = [
+        { type: 'replace-script-loader-url' as const, fromDomain: 'config.example.com', pathPrefix: '/settings' },
+      ]
+      const configRewrites = deriveRewrites(['config.example.com'], '/_scripts/p')
+      const code = [
+        'function log(u){console.log(u);}',
+        'var base="/settings",path=base+"/"+tenant+"/"+id+".js";',
+        'log(host!==cdn?proto+host+path:buildVendorUrl(path));',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
+      expect(result).toBe(code)
+    })
+
+    it('keeps minified variable names scoped when detecting path variables', () => {
+      const patches = [
+        { type: 'replace-script-loader-url' as const, fromDomain: 'config.example.com', pathPrefix: '/settings' },
+      ]
+      const configRewrites = deriveRewrites(['config.example.com'], '/_scripts/p')
+      const code = [
+        'function load(u){var s=document.createElement("script");s.src=u;}',
+        'var p=proto+cdn+"/sdk.js";',
+        'load(p+"?u="+id);',
+        'function init(){var p="/settings/"+tenant+"/"+id+".js";load(host!==cdn?proto+host+p:buildVendorUrl(p));}',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
+      expect(result).toContain('load(p+"?u="+id);')
+      expect(result).toContain('load(self.location.origin+"/_scripts/p/config.example.com"+p);')
+    })
+
+    it('keeps minified loader function names scoped', () => {
+      const patches = [
+        { type: 'replace-script-loader-url' as const, fromDomain: 'config.example.com', pathPrefix: '/settings' },
+      ]
+      const configRewrites = deriveRewrites(['config.example.com'], '/_scripts/p')
+      const code = [
+        'function load(u){console.log(u);}',
+        'var path="/settings/"+tenant+"/"+id+".js";',
+        'load(path);',
+        'function init(){function load(u){var s=document.createElement("script");s.src=u;}load(host!==cdn?proto+host+path:buildVendorUrl(path));}',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
+      expect(result).toContain('load(path);')
+      expect(result).toContain('load(self.location.origin+"/_scripts/p/config.example.com"+path);')
+    })
+
+    it('keeps function-expression loader declarations distinct in the same var statement', () => {
+      const patches = [
+        { type: 'replace-script-loader-url' as const, fromDomain: 'config.example.com', pathPrefix: '/settings' },
+      ]
+      const configRewrites = deriveRewrites(['config.example.com'], '/_scripts/p')
+      const code = [
+        'var load=function(u){var s=document.createElement("script");s.src=u},log=function(u){console.log(u)};',
+        'var path="/settings/"+tenant+"/"+id+".js";',
+        'load(host!==cdn?proto+host+path:buildVendorUrl(path));',
+        'log(path);',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
+      expect(result).toContain('load(self.location.origin+"/_scripts/p/config.example.com"+path);')
+      expect(result).toContain('log(path);')
+    })
+
+    it('does not treat wrapper functions as loaders based on nested functions', () => {
+      const patches = [
+        { type: 'replace-script-loader-url' as const, fromDomain: 'config.example.com', pathPrefix: '/settings' },
+      ]
+      const configRewrites = deriveRewrites(['config.example.com'], '/_scripts/p')
+      const code = [
+        'function wrapper(u){function nested(){var s=document.createElement("script");s.src=u}return nested;}',
+        'var path="/settings/"+tenant+"/"+id+".js";',
+        'wrapper(path);',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
+      expect(result).toBe(code)
+    })
+  })
+
   describe('fathom SDK self-hosted detection patching', () => {
     // Fathom is bundle-only (no proxy capability) — sdkPatches come from
     // BundleCapability.sdkPatches and are self-contained with their own domain.

--- a/test/unit/rewrite-ast.test.ts
+++ b/test/unit/rewrite-ast.test.ts
@@ -395,6 +395,38 @@ describe('rewriteScriptUrlsAST', () => {
       const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
       expect(result).toBe(code)
     })
+
+    it('handles loader args containing proxied domain literals without conflicting edits', () => {
+      const patches = [
+        { type: 'replace-script-loader-url' as const, fromDomain: 'config.example.com', pathPrefix: '/settings' },
+      ]
+      const configRewrites = deriveRewrites(['config.example.com'], '/_scripts/p')
+      // The literal inside the replaced arg would also match the domain rewrite —
+      // the loader rewrite must not leave a nested edit for it to conflict with.
+      const code = [
+        'function load(u){var s=document.createElement("script");s.src=u;}',
+        'var path="/settings/"+tenant+"/"+id+".js";',
+        'load(cond?"https://config.example.com/settings/fallback.js":path);',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
+      expect(result).toContain('load(self.location.origin+"/_scripts/p/config.example.com"+path);')
+    })
+
+    it('rewrites to the patch whose pathPrefix actually matched', () => {
+      const patches = [
+        { type: 'replace-script-loader-url' as const, fromDomain: 'other.example.com', pathPrefix: '/alpha' },
+        { type: 'replace-script-loader-url' as const, fromDomain: 'config.example.com', pathPrefix: '/settings' },
+      ]
+      const configRewrites = deriveRewrites(['other.example.com', 'config.example.com'], '/_scripts/p')
+      const code = [
+        'function load(u){var s=document.createElement("script");s.src=u;}',
+        'var path="/settings/"+tenant+"/"+id+".js";',
+        'load(host!==cdn?proto+host+path:buildVendorUrl(path));',
+      ].join('')
+      const result = rewriteScriptUrlsAST(code, 'vendor.js', configRewrites, patches)
+      expect(result).toContain('load(self.location.origin+"/_scripts/p/config.example.com"+path);')
+      expect(result).not.toContain('other.example.com')
+    })
   })
 
   describe('fathom SDK self-hosted detection patching', () => {

--- a/test/unit/transform.test.ts
+++ b/test/unit/transform.test.ts
@@ -643,8 +643,6 @@ const _sfc_main = /* @__PURE__ */ _defineComponent({
     })
 
     it('should bypass cache for registry scriptOptions.bundle force', async () => {
-      vi.mocked(hash).mockImplementationOnce(() => 'scevent.min')
-
       // Mock that cache exists and is fresh
       mockBundleStorage.hasItem.mockResolvedValue(true)
       mockBundleStorage.getItem.mockResolvedValue({ timestamp: Date.now() })

--- a/test/unit/transform.test.ts
+++ b/test/unit/transform.test.ts
@@ -642,6 +642,51 @@ const _sfc_main = /* @__PURE__ */ _defineComponent({
       expect(code).toMatchInlineSnapshot(`"const instance = useScript('/_scripts/assets/e3b0c44298fc1c14.js', )"`)
     })
 
+    it('should bypass cache for registry scriptOptions.bundle force', async () => {
+      vi.mocked(hash).mockImplementationOnce(() => 'scevent.min')
+
+      // Mock that cache exists and is fresh
+      mockBundleStorage.hasItem.mockResolvedValue(true)
+      mockBundleStorage.getItem.mockResolvedValue({ timestamp: Date.now() })
+      mockBundleStorage.getItemRaw.mockResolvedValue(Buffer.from('cached content'))
+
+      // Mock successful fetch for force download
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        headers: { get: () => null },
+      } as any)
+
+      const code = await transform(
+        `const instance = useScriptSnapchatPixel({
+          id: '2295cbcc-cb3f-4727-8c09-1133b742722c',
+          scriptOptions: {
+            bundle: 'force',
+            trigger: 'client'
+          }
+        })`,
+        {
+          renderedScript: new Map(),
+          scripts: [
+            {
+              bundle: {
+                resolve() {
+                  return 'https://sc-static.net/scevent.min.js'
+                },
+              },
+              import: {
+                name: 'useScriptSnapchatPixel',
+                from: '',
+              },
+            },
+          ] as any,
+        },
+      )
+
+      expect(fetch).toHaveBeenCalled()
+      expect(code).toContain('scriptInput: { src: \'/_scripts/assets/e3b0c44298fc1c14.js\' }')
+    })
+
     it('should store bundle metadata with timestamp on download', async () => {
       vi.mocked(hash).mockImplementationOnce(() => 'beacon.min')
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #822

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Bundled `scevent.min.js` was deriving its config host from the local asset URL, then loading `/config/...` from the app origin. This adds scoped SDK patches for `new URL(...).host` and script-loader URL arguments so Snapchat config loads go through the `tr.snapchat.com` proxy without depending on current minified names.

The Snapchat first-party e2e now forces a fresh upstream bundle and fails if `/config/...` is requested from the app origin. The bundled SDK regression test also derives Snapchat proxy settings from the registry so domains and patches cannot drift silently.
