### PR TITLE
fix: mark unhead peer dependency as optional

### DIFF
--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -105,6 +105,9 @@
     "@types/youtube": {
       "optional": true
     },
+    "@unhead/vue": {
+      "optional": true
+    },
     "posthog-js": {
       "optional": true
     }


### PR DESCRIPTION
## Summary

- mark `@unhead/vue` as an optional peer dependency
- avoid npm auto-installing Unhead 3 when Nuxt already provides a compatible Unhead 2 version

## Why

`@nuxt/scripts` supports both Unhead v2 and v3, but npm currently auto-installs `@unhead/vue@3.x` for Nuxt 4.4.8 apps that do not directly declare the peer. That can create mixed Unhead v2/v3 installs and Nitro node-server output can package an incomplete `unhead` runtime, causing SSR imports like `unhead/server` to fail at runtime.

Making the peer optional keeps the existing compatibility range, while allowing the consuming Nuxt app's existing Unhead version to be reused.

## Verification

- confirmed npm reuses Nuxt's `@unhead/vue@2.1.15` with this metadata change
- built a minimal Nuxt app using `@nuxt/scripts` and imported the generated renderer successfully
- ran package build, lint, type tests, unit/runtime tests, and full build

