### PR TITLE
fix: respect `warmupStrategy: false` when defaulting to preload

### DIFF
--- a/packages/script/src/runtime/composables/useScript.ts
+++ b/packages/script/src/runtime/composables/useScript.ts
@@ -265,7 +265,8 @@ export function useScript<T extends Record<symbol | string, any> = Record<symbol
     }
   }
   else if (options.trigger === 'onNuxtReady' || options.trigger === 'client') {
-    if (!options.warmupStrategy) {
+    // `false` is a valid value to disable warmup (#826)
+    if (options.warmupStrategy === undefined) {
       options.warmupStrategy = 'preload'
     }
     if (options.trigger === 'onNuxtReady') {

--- a/test/nuxt-runtime/warmup.nuxt.test.ts
+++ b/test/nuxt-runtime/warmup.nuxt.test.ts
@@ -101,6 +101,18 @@ describe.skipIf(process.env.CI)('script warmup', () => {
     `)
     script.remove()
   })
+  it('warmupStrategy: false disables preload - #826', async () => {
+    const head = createHead({ disableDefaults: true })
+    const script = useScript({
+      src: 'https://example.com/no-preload.js',
+    }, {
+      warmupStrategy: false,
+      head,
+    })
+    const ssr = await renderSSRHead(head)
+    expect(ssr.headTags).toMatchInlineSnapshot(`""`)
+    script.remove()
+  })
   it('respects useScript privacy controls', async () => {
     const head = createHead({ disableDefaults: true })
     const script = useScript({


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #826

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`useScript()` defaulted `warmupStrategy` with a falsy check (`if (!options.warmupStrategy)`), so an explicit `warmupStrategy: false` was overridden to `'preload'` and a `<link rel="preload">` was still rendered. 