### PR TITLE
fix(proxy): preserve non-JSON request bodies

### DIFF
--- a/packages/script/src/runtime/server/proxy-handler.ts
+++ b/packages/script/src/runtime/server/proxy-handler.ts
@@ -137,8 +137,11 @@ export default defineEventHandler(async (event) => {
   const compressionParam = (originalQuery.compression as string) || ''
   const method = event.method?.toUpperCase()
   const isWriteMethod = method === 'POST' || method === 'PUT' || method === 'PATCH'
-  const isFormBody = contentType.includes('application/x-www-form-urlencoded')
-  const isJsonBody = contentType.includes('json')
+  const transformableBodyType = contentType.includes('application/x-www-form-urlencoded')
+    ? 'form'
+    : contentType.includes('json')
+      ? 'json'
+      : undefined
 
   // Only parse formats whose structure is known. Opaque bodies may contain binary
   // data despite a text content type, as with PostHog's gzip payloads.
@@ -150,7 +153,7 @@ export default defineEventHandler(async (event) => {
   const shouldTransformBody = isWriteMethod
     && anyPrivacy
     && !hasOpaqueBodyEncoding
-    && (isJsonBody || isFormBody)
+    && transformableBodyType !== undefined
 
   // Build target URL with stripped query params
   let targetUrl = targetBase + remainingPath
@@ -271,7 +274,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Process request body: either stream through raw or read + transform
-  let body: string | Record<string, unknown> | unknown[] | undefined
+  let body: string | Record<string, unknown> | unknown[] | number | boolean | null | undefined
   let rawBody: unknown
   // When true, body is not read — the raw request stream is piped directly to upstream
   let passthroughBody = false
@@ -281,16 +284,16 @@ export default defineEventHandler(async (event) => {
       // No safe transforms available or needed. Stream the original bytes directly.
       passthroughBody = true
     }
-    else if (isFormBody) {
+    else if (transformableBodyType === 'form') {
       const formBody = await readRawBody(event)
       rawBody = formBody
 
       if (formBody != null) {
         // Preserve repeated keys while applying privacy transforms to form fields.
         const params = new URLSearchParams(formBody)
-        const formRecord: Record<string, unknown> = {}
+        const formRecord: Record<string, unknown> = Object.create(null)
         for (const [key, value] of params.entries()) {
-          if (key in formRecord) {
+          if (Object.hasOwn(formRecord, key)) {
             const existing = formRecord[key]
             formRecord[key] = Array.isArray(existing) ? [...existing, value] : [existing, value]
           }
@@ -300,17 +303,17 @@ export default defineEventHandler(async (event) => {
         }
 
         const stripped = stripPayloadFingerprinting(formRecord, privacy)
-        const transformed = new URLSearchParams()
+        const transformedValues = new Map<string, unknown[]>()
         for (const [key, value] of Object.entries(stripped)) {
+          transformedValues.set(key, Array.isArray(value) ? [...value] : [value])
+        }
+
+        const transformed = new URLSearchParams()
+        for (const [key] of params.entries()) {
+          const value = transformedValues.get(key)?.shift()
           if (value === undefined || value === null)
             continue
-          if (Array.isArray(value)) {
-            for (const item of value)
-              transformed.append(key, typeof item === 'string' ? item : JSON.stringify(item))
-          }
-          else {
-            transformed.append(key, typeof value === 'string' ? value : JSON.stringify(value))
-          }
+          transformed.append(key, typeof value === 'string' ? value : JSON.stringify(value))
         }
         body = transformed.toString()
       }
@@ -319,46 +322,21 @@ export default defineEventHandler(async (event) => {
       // JSON body with privacy transforms.
       rawBody = await readBody(event)
 
-      if (rawBody != null) {
-        if (Array.isArray(rawBody)) {
-          // JSON array body (e.g. batch payloads) — strip each element individually
-          body = rawBody.map(item =>
-            item && typeof item === 'object' && !Array.isArray(item)
-              ? stripPayloadFingerprinting(item as Record<string, unknown>, privacy)
-              : item,
-          )
-        }
-        else if (typeof rawBody === 'object') {
-          // JSON object body, strip fingerprinting recursively.
-          body = stripPayloadFingerprinting(rawBody as Record<string, unknown>, privacy)
-        }
-        else if (typeof rawBody === 'string') {
-          // readBody may return a string for JSON primitives or malformed JSON.
-          let parsed: unknown = null
-          try {
-            parsed = JSON.parse(rawBody)
-          }
-          catch {
-            // Preserve malformed JSON for the upstream service to handle.
-          }
-
-          if (Array.isArray(parsed)) {
-            body = parsed.map(item =>
-              item && typeof item === 'object' && !Array.isArray(item)
-                ? stripPayloadFingerprinting(item as Record<string, unknown>, privacy)
-                : item,
-            )
-          }
-          else if (parsed && typeof parsed === 'object') {
-            body = stripPayloadFingerprinting(parsed as Record<string, unknown>, privacy)
-          }
-          else {
-            body = rawBody
-          }
-        }
-        else {
-          body = rawBody as string
-        }
+      if (Array.isArray(rawBody)) {
+        // JSON array body (e.g. batch payloads) — strip each element individually
+        body = rawBody.map(item =>
+          item && typeof item === 'object' && !Array.isArray(item)
+            ? stripPayloadFingerprinting(item as Record<string, unknown>, privacy)
+            : item,
+        )
+      }
+      else if (rawBody !== null && typeof rawBody === 'object') {
+        // JSON object body, strip fingerprinting recursively.
+        body = stripPayloadFingerprinting(rawBody as Record<string, unknown>, privacy)
+      }
+      else {
+        // JSON primitives do not contain fingerprinting fields, but must retain JSON encoding.
+        body = rawBody as string | number | boolean | null | undefined
       }
     }
   }
@@ -400,7 +378,7 @@ export default defineEventHandler(async (event) => {
     fetchBody = getRequestWebStream(event) as BodyInit | undefined
   }
   else if (body !== undefined) {
-    fetchBody = typeof body === 'string' ? body : JSON.stringify(body)
+    fetchBody = transformableBodyType === 'json' ? JSON.stringify(body) : String(body)
   }
 
   let response: Response

--- a/packages/script/src/runtime/server/proxy-handler.ts
+++ b/packages/script/src/runtime/server/proxy-handler.ts
@@ -1,5 +1,5 @@
 import type { ProxyPrivacyInput, ResolvedProxyPrivacy } from './utils/privacy'
-import { createError, defineEventHandler, getHeaders, getQuery, getRequestIP, getRequestWebStream, readBody, setResponseHeader, setResponseStatus } from 'h3'
+import { createError, defineEventHandler, getHeaders, getQuery, getRequestIP, getRequestWebStream, readBody, readRawBody, setResponseHeader, setResponseStatus } from 'h3'
 import { useNitroApp, useRuntimeConfig } from 'nitropack/runtime'
 import { matchDomain } from './utils/match-domain'
 import {
@@ -131,20 +131,26 @@ export default defineEventHandler(async (event) => {
   const privacy = globalPrivacy !== undefined ? mergePrivacy(perScriptResolved, globalPrivacy) : perScriptResolved
   const anyPrivacy = privacy.ip || privacy.userAgent || privacy.language || privacy.screen || privacy.timezone || privacy.hardware
 
-  // Detect binary/compressed bodies that cannot be safely parsed as text.
-  // These must be passed through as raw bytes to avoid corruption:
-  // - content-encoding: transport-level compression (gzip, br, etc.)
-  // - application/octet-stream: explicitly binary content
-  // - ?compression=gzip-js: client-side compression (e.g. PostHog sends gzip bytes as text/plain)
   const originalHeaders = getHeaders(event)
   const originalQuery = getQuery(event)
-  const contentType = originalHeaders['content-type'] || ''
+  const contentType = originalHeaders['content-type']?.toLowerCase() || ''
   const compressionParam = (originalQuery.compression as string) || ''
-  const isBinaryBody = Boolean(
+  const method = event.method?.toUpperCase()
+  const isWriteMethod = method === 'POST' || method === 'PUT' || method === 'PATCH'
+  const isFormBody = contentType.includes('application/x-www-form-urlencoded')
+  const isJsonBody = contentType.includes('json')
+
+  // Only parse formats whose structure is known. Opaque bodies may contain binary
+  // data despite a text content type, as with PostHog's gzip payloads.
+  const hasOpaqueBodyEncoding = Boolean(
     originalHeaders['content-encoding']
     || contentType.includes('octet-stream')
     || (compressionParam && COMPRESSION_RE.test(compressionParam)),
   )
+  const shouldTransformBody = isWriteMethod
+    && anyPrivacy
+    && !hasOpaqueBodyEncoding
+    && (isJsonBody || isFormBody)
 
   // Build target URL with stripped query params
   let targetUrl = targetBase + remainingPath
@@ -192,10 +198,9 @@ export default defineEventHandler(async (event) => {
     if (SENSITIVE_HEADERS.includes(lowerKey))
       continue
 
-    // Skip content-length when body will be modified by privacy transforms
-    // (preserved for binary passthrough and no-privacy paths)
+    // Skip content-length when body will be modified by privacy transforms.
     if (lowerKey === 'content-length') {
-      if (anyPrivacy && !isBinaryBody)
+      if (shouldTransformBody)
         continue
       headers[lowerKey] = value
       continue
@@ -270,16 +275,48 @@ export default defineEventHandler(async (event) => {
   let rawBody: unknown
   // When true, body is not read — the raw request stream is piped directly to upstream
   let passthroughBody = false
-  const method = event.method?.toUpperCase()
-  const isWriteMethod = method === 'POST' || method === 'PUT' || method === 'PATCH'
 
   if (isWriteMethod) {
-    if (isBinaryBody || !anyPrivacy) {
-      // No transforms needed — don't read the body at all, stream it through directly.
+    if (!shouldTransformBody) {
+      // No safe transforms available or needed. Stream the original bytes directly.
       passthroughBody = true
     }
+    else if (isFormBody) {
+      const formBody = await readRawBody(event)
+      rawBody = formBody
+
+      if (formBody != null) {
+        // Preserve repeated keys while applying privacy transforms to form fields.
+        const params = new URLSearchParams(formBody)
+        const formRecord: Record<string, unknown> = {}
+        for (const [key, value] of params.entries()) {
+          if (key in formRecord) {
+            const existing = formRecord[key]
+            formRecord[key] = Array.isArray(existing) ? [...existing, value] : [existing, value]
+          }
+          else {
+            formRecord[key] = value
+          }
+        }
+
+        const stripped = stripPayloadFingerprinting(formRecord, privacy)
+        const transformed = new URLSearchParams()
+        for (const [key, value] of Object.entries(stripped)) {
+          if (value === undefined || value === null)
+            continue
+          if (Array.isArray(value)) {
+            for (const item of value)
+              transformed.append(key, typeof item === 'string' ? item : JSON.stringify(item))
+          }
+          else {
+            transformed.append(key, typeof value === 'string' ? value : JSON.stringify(value))
+          }
+        }
+        body = transformed.toString()
+      }
+    }
     else {
-      // Text body with privacy transforms — parse and strip fingerprinting
+      // JSON body with privacy transforms.
       rawBody = await readBody(event)
 
       if (rawBody != null) {
@@ -292,69 +329,31 @@ export default defineEventHandler(async (event) => {
           )
         }
         else if (typeof rawBody === 'object') {
-          // JSON object body - strip fingerprinting recursively
+          // JSON object body, strip fingerprinting recursively.
           body = stripPayloadFingerprinting(rawBody as Record<string, unknown>, privacy)
         }
         else if (typeof rawBody === 'string') {
-          if (contentType.includes('application/x-www-form-urlencoded')) {
-            // URL-encoded form data — preserve repeated keys (e.g. ?tag=a&tag=b)
-            const params = new URLSearchParams(rawBody)
-            const obj: Record<string, unknown> = {}
-            for (const [key, value] of params.entries()) {
-              if (key in obj) {
-                // Repeated key → accumulate as array
-                const existing = obj[key]
-                obj[key] = Array.isArray(existing) ? [...existing, value] : [existing, value]
-              }
-              else {
-                obj[key] = value
-              }
-            }
-            const stripped = stripPayloadFingerprinting(obj, privacy)
-            // Reconstruct form data, expanding arrays back to repeated keys
-            const out = new URLSearchParams()
-            for (const [k, v] of Object.entries(stripped)) {
-              if (v === undefined || v === null)
-                continue
-              if (Array.isArray(v)) {
-                for (const item of v)
-                  out.append(k, typeof item === 'string' ? item : JSON.stringify(item))
-              }
-              else {
-                out.append(k, typeof v === 'string' ? v : JSON.stringify(v))
-              }
-            }
-            body = out.toString()
+          // readBody may return a string for JSON primitives or malformed JSON.
+          let parsed: unknown = null
+          try {
+            parsed = JSON.parse(rawBody)
+          }
+          catch {
+            // Preserve malformed JSON for the upstream service to handle.
+          }
+
+          if (Array.isArray(parsed)) {
+            body = parsed.map(item =>
+              item && typeof item === 'object' && !Array.isArray(item)
+                ? stripPayloadFingerprinting(item as Record<string, unknown>, privacy)
+                : item,
+            )
+          }
+          else if (parsed && typeof parsed === 'object') {
+            body = stripPayloadFingerprinting(parsed as Record<string, unknown>, privacy)
           }
           else {
-            // Try parsing as JSON: explicit JSON content-type, or heuristic for
-            // sendBeacon payloads that send JSON with text/plain content-type
-            const maybeJson = contentType.includes('json')
-              || (rawBody.startsWith('{') || rawBody.startsWith('['))
-            if (maybeJson) {
-              let parsed: unknown = null
-              try {
-                parsed = JSON.parse(rawBody)
-              }
-              catch { /* not valid JSON — fall through to raw */ }
-
-              if (Array.isArray(parsed)) {
-                body = parsed.map(item =>
-                  item && typeof item === 'object' && !Array.isArray(item)
-                    ? stripPayloadFingerprinting(item as Record<string, unknown>, privacy)
-                    : item,
-                )
-              }
-              else if (parsed && typeof parsed === 'object') {
-                body = stripPayloadFingerprinting(parsed as Record<string, unknown>, privacy)
-              }
-              else {
-                body = rawBody
-              }
-            }
-            else {
-              body = rawBody
-            }
+            body = rawBody
           }
         }
         else {

--- a/test/unit/proxy-handler-body.test.ts
+++ b/test/unit/proxy-handler-body.test.ts
@@ -26,6 +26,7 @@ describe('proxy handler request bodies (#836)', () => {
   let upstreamPort: number
   let proxyPort: number
   let capturedBody = Buffer.alloc(0)
+  let capturedContentLength: string | undefined
   let capturedContentType: string | undefined
   const realFetch = globalThis.fetch
 
@@ -34,6 +35,7 @@ describe('proxy handler request bodies (#836)', () => {
     upstreamApp.use('/', defineEventHandler(async (event) => {
       const rawBody = await readRawBody(event, false)
       capturedBody = rawBody ? Buffer.from(rawBody) : Buffer.alloc(0)
+      capturedContentLength = event.headers.get('content-length') ?? undefined
       capturedContentType = event.headers.get('content-type') ?? undefined
       return { status: 1 }
     }))
@@ -61,6 +63,7 @@ describe('proxy handler request bodies (#836)', () => {
 
   beforeEach(() => {
     capturedBody = Buffer.alloc(0)
+    capturedContentLength = undefined
     capturedContentType = undefined
   })
 
@@ -87,7 +90,8 @@ describe('proxy handler request bodies (#836)', () => {
   })
 
   it('preserves form encoding when privacy transforms are active', async () => {
-    const formBody = 'event=%24pageview&tag=a&tag=b&sr=2560x1440'
+    const formBody = 'tag=a&event=%24pageview&tag=b&hardwareConcurrency=128'
+    const transformedBody = 'tag=a&event=%24pageview&tag=b&hardwareConcurrency=16'
 
     const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/i/v0/e/`, {
       method: 'POST',
@@ -96,7 +100,60 @@ describe('proxy handler request bodies (#836)', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(capturedBody.toString()).toBe('event=%24pageview&tag=a&tag=b&sr=1920x1080')
+    expect(capturedBody.toString()).toBe(transformedBody)
+    expect(capturedContentLength).toBe(String(Buffer.byteLength(transformedBody)))
+    expect(capturedContentLength).not.toBe(String(Buffer.byteLength(formBody)))
     expect(capturedContentType).toBe('application/x-www-form-urlencoded')
+  })
+
+  it('applies privacy transforms to JSON objects and arrays', async () => {
+    const bodies = [
+      {
+        input: { event: '$pageview', sr: '2560x1440' },
+        expected: { event: '$pageview', sr: '1920x1080' },
+      },
+      {
+        input: [{ hardwareConcurrency: 128 }, 'unchanged'],
+        expected: [{ hardwareConcurrency: 16 }, 'unchanged'],
+      },
+    ]
+
+    for (const { input, expected } of bodies) {
+      const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/i/v0/e/`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+
+      expect(response.status).toBe(200)
+      expect(JSON.parse(capturedBody.toString())).toEqual(expected)
+    }
+  })
+
+  it.each([
+    ['string', '"value"'],
+    ['number', '42'],
+    ['boolean', 'true'],
+    ['null', 'null'],
+  ])('preserves JSON %s primitives', async (_name, jsonBody) => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/i/v0/e/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: jsonBody,
+    })
+
+    expect(response.status).toBe(200)
+    expect(capturedBody.toString()).toBe(jsonBody)
+  })
+
+  it('rejects malformed JSON before forwarding upstream', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/i/v0/e/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"event":',
+    })
+
+    expect(response.status).toBe(400)
+    expect(capturedBody).toHaveLength(0)
   })
 })

--- a/test/unit/proxy-handler-body.test.ts
+++ b/test/unit/proxy-handler-body.test.ts
@@ -1,0 +1,102 @@
+import type { Server } from 'node:http'
+import { createServer } from 'node:http'
+import { gzipSync } from 'node:zlib'
+import { createApp, defineEventHandler, readRawBody, toNodeListener } from 'h3'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import proxyHandler from '../../packages/script/src/runtime/server/proxy-handler'
+
+vi.mock('nitropack/runtime', () => ({
+  useRuntimeConfig: () => ({
+    'nuxt-scripts-proxy': {
+      proxyPrefix: '/_scripts/p',
+      domainPrivacy: {
+        'upstream.test': true,
+      },
+      debug: false,
+    },
+  }),
+  useNitroApp: () => ({
+    hooks: { callHook: async () => {} },
+  }),
+}))
+
+describe('proxy handler request bodies (#836)', () => {
+  let upstreamServer: Server
+  let proxyServer: Server
+  let upstreamPort: number
+  let proxyPort: number
+  let capturedBody = Buffer.alloc(0)
+  let capturedContentType: string | undefined
+  const realFetch = globalThis.fetch
+
+  beforeAll(async () => {
+    const upstreamApp = createApp()
+    upstreamApp.use('/', defineEventHandler(async (event) => {
+      const rawBody = await readRawBody(event, false)
+      capturedBody = rawBody ? Buffer.from(rawBody) : Buffer.alloc(0)
+      capturedContentType = event.headers.get('content-type') ?? undefined
+      return { status: 1 }
+    }))
+
+    upstreamServer = createServer(toNodeListener(upstreamApp))
+    await new Promise<void>(resolve => upstreamServer.listen(0, resolve))
+    upstreamPort = (upstreamServer.address() as { port: number }).port
+
+    globalThis.fetch = (input, init) => {
+      const requestUrl = input instanceof Request ? input.url : String(input)
+      const url = new URL(requestUrl)
+      if (url.hostname === 'upstream.test') {
+        const redirected = `http://127.0.0.1:${upstreamPort}${url.pathname}${url.search}`
+        return realFetch(redirected, init)
+      }
+      return realFetch(input, init)
+    }
+
+    const proxyApp = createApp()
+    proxyApp.use(proxyHandler)
+    proxyServer = createServer(toNodeListener(proxyApp))
+    await new Promise<void>(resolve => proxyServer.listen(0, resolve))
+    proxyPort = (proxyServer.address() as { port: number }).port
+  })
+
+  beforeEach(() => {
+    capturedBody = Buffer.alloc(0)
+    capturedContentType = undefined
+  })
+
+  afterAll(async () => {
+    globalThis.fetch = realFetch
+    await Promise.all([
+      new Promise<void>(resolve => upstreamServer.close(() => resolve())),
+      new Promise<void>(resolve => proxyServer.close(() => resolve())),
+    ])
+  })
+
+  it('preserves an opaque gzip body without a compression query parameter', async () => {
+    const compressed = gzipSync(JSON.stringify({ event: '$pageview' }))
+
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/i/v0/e/`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: compressed,
+    })
+
+    expect(response.status).toBe(200)
+    expect(capturedBody.equals(compressed)).toBe(true)
+    expect(capturedContentType).toBe('text/plain')
+  })
+
+  it('preserves form encoding when privacy transforms are active', async () => {
+    const formBody = 'event=%24pageview&tag=a&tag=b&sr=2560x1440'
+
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/i/v0/e/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+    })
+
+    expect(response.status).toBe(200)
+    expect(capturedBody.toString()).toBe('event=%24pageview&tag=a&tag=b&sr=1920x1080')
+    expect(capturedContentType).toBe('application/x-www-form-urlencoded')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #836

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

PostHog 1.405.2 sends gzip captures as `text/plain` without a `compression` query parameter. The proxy now streams opaque bodies unchanged and re-encodes `application/x-www-form-urlencoded` bodies after privacy transforms.