### PR TITLE
test: fix Nuxt 4.5 and TikTok e2e failures

### DIFF
--- a/test/e2e/tiktok-pixel.test.ts
+++ b/test/e2e/tiktok-pixel.test.ts
@@ -60,7 +60,9 @@ describe('tiktokPixel', async () => {
           .map(s => s.src)
           .find((s) => {
             try {
-              return new URL(s).hostname === 'analytics.tiktok.com'
+              const scriptUrl = new URL(s)
+              return scriptUrl.hostname === 'analytics.tiktok.com'
+                && scriptUrl.pathname === '/i18n/pixel/events.js'
             }
             catch {
               return false

--- a/test/fixtures/basic/pages/bundle-use-script.vue
+++ b/test/fixtures/basic/pages/bundle-use-script.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
-import { injectHead, ref, useScript } from '#imports'
+import { ref, useScript } from '#imports'
 
-const { onLoaded } = useScript<{ myScript: (arg: string) => void }>(
+const { id, onLoaded } = useScript<{ myScript: (arg: string) => void }>(
   // need a real script to bundle
   'https://code.jquery.com/jquery-3.6.0.min.js',
   {
@@ -16,10 +16,8 @@ const { onLoaded } = useScript<{ myScript: (arg: string) => void }>(
 )
 
 const scriptSrc = ref('https://code.jquery.com/jquery-3.6.0.min.js')
-onLoaded(async () => {
-  const head = injectHead()
-  const tags = await head.resolveTags()
-  scriptSrc.value = tags.filter(s => s.tag === 'script')[0].props.src
+onLoaded(() => {
+  scriptSrc.value = id
 })
 </script>
 


### PR DESCRIPTION
### 🔗 Linked issue

Related to #837

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt 4.5 removed the internal Unhead `resolveTags()` method used by the bundle fixture, so its loaded callback never updated the rendered script URL. Read the public script instance `id` instead, and make the TikTok test select its `events.js` loader rather than an injected runtime script.
