### PR TITLE
fix: import `defineNuxtPlugin` in intercept plugin

### DIFF
--- a/packages/script/src/plugins/intercept.ts
+++ b/packages/script/src/plugins/intercept.ts
@@ -13,7 +13,9 @@
  */
 export function generateInterceptPluginContents(proxyPrefix: string, options?: { testMode?: boolean, domainAliases?: Record<string, string> }): string {
   const testMode = options?.testMode ?? false
-  return `export default defineNuxtPlugin({
+  return `import { defineNuxtPlugin } from 'nuxt/app'
+
+export default defineNuxtPlugin({
   name: 'nuxt-scripts:intercept',
   enforce: 'pre',
   setup() {

--- a/test/unit/proxy-alias-generators.test.ts
+++ b/test/unit/proxy-alias-generators.test.ts
@@ -29,6 +29,11 @@ describe('proxy alias - generated runtime code (#814)', () => {
   })
 
   describe('generateInterceptPluginContents', () => {
+    it('imports defineNuxtPlugin when Nuxt auto imports are disabled (#841)', () => {
+      const code = generateInterceptPluginContents('/_scripts/p')
+      expect(code).toContain('import { defineNuxtPlugin } from \'nuxt/app\'')
+    })
+
     it('embeds the alias map into the client intercept plugin', () => {
       const code = generateInterceptPluginContents('/_scripts/p', { domainAliases: ALIASES })
       expect(code).toContain('const domainAliases = {"us.i.posthog.com":"ph"}')


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #841

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The generated proxy intercept plugin called `defineNuxtPlugin` without importing it. Add an explicit `nuxt/app` import so apps with `imports.autoImport: false` can initialize the plugin.