### PR TITLE
fix(gtm): don't declare `dataLayer` on the global `Window`

### DIFF
--- a/packages/script/src/runtime/registry/google-tag-manager.ts
+++ b/packages/script/src/runtime/registry/google-tag-manager.ts
@@ -72,9 +72,17 @@ export interface GoogleTagManagerApi {
 
 /**
  * Enhanced window type with GTM
+ *
+ * `dataLayer` is deliberately NOT declared globally. Its name is configurable through the
+ * `l` / `dataLayer` options, so `window.dataLayer` is not guaranteed to exist, and declaring it
+ * here makes this package irreconcilable with any other package that declares `Window.dataLayer`
+ * (for example `@gtm-support/core`, used by `@gtm-support/vue-gtm`): the two declarations cannot
+ * merge, so consumers of both get an unsuppressable TS2430 at every one of their own `Window`
+ * augmentations. Read it through the typed proxy returned by `useScriptGoogleTagManager()`
+ * instead, which is also the only access path that respects a custom dataLayer name.
  */
 declare global {
-  interface Window extends GoogleTagManagerApi {}
+  interface Window extends Pick<GoogleTagManagerApi, 'google_tag_manager'> {}
 }
 
 export { GoogleTagManagerOptions }

--- a/test/types/global-window.test-d.ts
+++ b/test/types/global-window.test-d.ts
@@ -1,0 +1,31 @@
+import type { GoogleTagManagerApi } from '../../packages/script/src/runtime/registry/google-tag-manager'
+import { describe, expectTypeOf, it } from 'vitest'
+
+/**
+ * Regression guard for #852.
+ *
+ * `@gtm-support/core` (the engine behind `@gtm-support/vue-gtm`) declares
+ * `Window.dataLayer?: DataLayerObject[]`. Interface declarations merge, so if this package
+ * also declares `dataLayer` on the global `Window`, the merged `Window` fails this package's
+ * own `extends` clause. TypeScript then reports TS2430 at every one of the consumer's own
+ * `Window` augmentations, which the consumer cannot suppress.
+ *
+ * `dataLayer` must stay off the global `Window`. Its name is configurable through the
+ * `l` / `dataLayer` options anyway, so `window.dataLayer` was never guaranteed to exist.
+ * The proxy returned by `useScriptGoogleTagManager()` is the supported access path.
+ */
+describe('global `Window` augmentation', () => {
+  it('does not declare `dataLayer`', () => {
+    expectTypeOf<'dataLayer' extends keyof Window ? true : false>().toEqualTypeOf<false>()
+  })
+
+  it('keeps `google_tag_manager` declared', () => {
+    // `useScriptGoogleTagManager`'s `use()` reads `window.google_tag_manager` directly.
+    expectTypeOf<Window['google_tag_manager']>().toEqualTypeOf<GoogleTagManagerApi['google_tag_manager']>()
+  })
+
+  it('still types `dataLayer` on the GTM proxy API', () => {
+    expectTypeOf<GoogleTagManagerApi['dataLayer']>().not.toBeAny()
+    expectTypeOf<GoogleTagManagerApi['dataLayer']['push']>().toBeCallableWith({ event: 'test' })
+  })
+})


### PR DESCRIPTION
Fixes #852.

### Problem

The GTM registry augments the global `Window` with the entire `GoogleTagManagerApi`:

```ts
export interface GoogleTagManagerApi {
  google_tag_manager: GoogleTagManagerInstance
  dataLayer: DataLayer & { push: DataLayerPush }   // required
}

declare global {
  interface Window extends GoogleTagManagerApi {}
}
```

This makes `@nuxt/scripts` irreconcilable with any other package that declares `Window.dataLayer`. The common case is [`@gtm-support/core`](https://www.npmjs.com/package/@gtm-support/core) — the engine behind `@gtm-support/vue-gtm`, which a lot of Nuxt/Vue apps still use for GTM:

```ts
// @gtm-support/core/lib/index.d.ts
declare global {
  interface Window {
    dataLayer?: DataLayerObject[];   // optional, different element type
  }
}
```

The two declarations merge into one `Window`, which then fails its own `extends GoogleTagManagerApi` check. The result is `TS2430` reported at **every one of the consumer's own `Window` augmentations** — nowhere near the actual cause, and not suppressable from consumer code, since neither declaration belongs to them.

`tsc` 5.9.3 never verifies merged interfaces against their bases, so it stays silent. **TypeScript 7 (tsgo) does check, and reports it** — so this repo will hit it itself once #827 lands.

### The obvious fix does not work

#852 proposed making `dataLayer` optional. I checked, and that is **not sufficient** — there are two independent incompatibilities stacked, and making it optional only reveals the second:

```
Type 'DataLayerObject[]' is not assignable to type 'DataLayer & { push: DataLayerPush; }'.
  Type 'DataLayerObject[]' is not assignable to type '{ push: DataLayerPush; }'.
    Types of property 'push' are incompatible.
      Type '(...items: DataLayerObject[]) => number' is not assignable to type 'DataLayerPush'.
        Types of parameters 'items' and 'command' are incompatible.
          Type 'string' is not assignable to type 'DataLayerObject'.
```

`Array<T>.push` is `(...items: T[]) => number`, while `DataLayerPush`'s first overload begins `(command: string, ...)`. No amount of optionality reconciles that with a foreign element type. Any fix that keeps `dataLayer` in the global augmentation stays broken.

### Repro

Four files, `strict`, `skipLibCheck` — one file per package plus a consumer that augments `Window` (as most apps do):

<details>
<summary>files</summary>

```ts
// gtm-support.d.ts  — verbatim shape from @gtm-support/core
interface DataLayerObject extends Record<string, any> { event?: string }
declare global { interface Window { dataLayer?: DataLayerObject[] } }
export { type DataLayerObject }
```

```ts
// consumer.ts — any first-party Window augmentation
export {}
declare global { interface Window { utmData?: Record<string, string> } }
```

plus `nuxt-scripts.d.ts` carrying the registry's type block.

</details>

| Variant | TS 7.0.2 | tsc 5.9.3 |
| --- | --- | --- |
| current `main` | ❌ `TS2430` | ✅ silent (never checks) |
| `dataLayer` made optional (#852's proposal) | ❌ `TS2430` | ✅ silent |
| **this PR** | ✅ clean | ✅ clean |

### The fix

Declare only the member that is actually global and actually unambiguous:

```diff
-  interface Window extends GoogleTagManagerApi {}
+  interface Window extends Pick<GoogleTagManagerApi, 'google_tag_manager'> {}
```

### Why this is safe

- **`GoogleTagManagerApi` is untouched**, so `useScriptGoogleTagManager<T extends GoogleTagManagerApi>()` and the `use()` return type keep their exact shape. Anyone reading `dataLayer` off the returned proxy is unaffected.
- **The registry never relied on the global declaration for `dataLayer`.** It reads `(window as any)[dataLayerName]` and casts — because the name is configurable. `window.google_tag_manager` *is* read directly (`use()`), which is why that member stays declared.
- **Nothing else in this repo depends on the global `dataLayer` typing.** The four `window.dataLayer` occurrences are all inside `innerHTML` template strings (`playground/.../unhead.vue`, `scripts/generate-sizes.ts`), prose in an example (`examples/regional-consent/app.vue`), or already `(window as any)` (`test/nuxt-runtime/consent-default.nuxt.test.ts`).
- **Declaring it globally was inaccurate anyway.** The dataLayer name is configurable via the `l` / `dataLayer` options, so `window.dataLayer` is not guaranteed to exist; the typed proxy is the only access path that respects a custom name.

### Note on scope

This is a type-level change only — zero runtime bytes.

It is technically breaking for anyone who reads `window.dataLayer` directly *and* relies on this package to type it. That was arguably never a promise this package should have made (the name is configurable), and such code keeps working with a one-line local augmentation or by using the `useScriptGoogleTagManager()` proxy. Happy to put it behind a major, or to add the narrower `Window { dataLayer?: unknown }` shim instead, if you would prefer — whichever you would rather land.

I verified the above with the minimal reproduction (exact declarations from both packages, TS 7.0.2 and 5.9.3); I have not run the full repo test suite locally.
