### PR TITLE
chore: use `import.meta.dirname` in devtools-app config

### DIFF
--- a/packages/devtools-app/nuxt.config.ts
+++ b/packages/devtools-app/nuxt.config.ts
@@ -10,7 +10,7 @@ export default defineNuxtConfig({
 
   scripts: false,
 
-  css: [resolve(__dirname, 'assets/css/global.css')],
+  css: [resolve(import.meta.dirname, 'assets/css/global.css')],
 
   fonts: {
     families: [
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
       ],
     },
     output: {
-      publicDir: resolve(__dirname, '../script/dist/devtools-client'),
+      publicDir: resolve(import.meta.dirname, '../script/dist/devtools-client'),
     },
   },
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted this remnant of cjs utils (which aren't present in esm) here - only working because we load modules with `jiti`, but this isn't guaranteed in future.