### PR TITLE
fix(cloudflare): keep Undici out of Worker bundles

### DIFF
--- a/packages/script/src/module.ts
+++ b/packages/script/src/module.ts
@@ -41,7 +41,7 @@ import { NuxtScriptBundleTransformer } from './plugins/transform'
 import { aliasProxyValue, buildDomainAliasMap, invertAliasMap, isSafeAliasSegment } from './proxy-alias'
 import { buildProxyConfigsFromRegistry, generatePartytownResolveUrl, getPartytownForwards, registry, resolveCapabilities } from './registry'
 import { ensureNuxtScriptsCacheStorage } from './runtime/server/utils/cache-config'
-import { isPublicNetworkHostname } from './runtime/server/utils/network-host'
+import { isPublicNetworkHostname } from './runtime/server/utils/network-hostname'
 import { registerTypeTemplates, templatePlugin, templateTriggerResolver } from './templates'
 import { validateScriptsEnvVars } from './validate-env'
 
@@ -321,6 +321,15 @@ export default defineNuxtModule<ModuleOptions>({
       logger.debug('The module is disabled, skipping setup.')
       return
     }
+    const networkDispatcherAlias = '#nuxt-scripts/network-dispatcher'
+    const nodeNetworkDispatcherPath = await resolvePath('./runtime/server/utils/network-dispatcher.node')
+    const platformNetworkDispatcherPath = await resolvePath('./runtime/server/utils/network-dispatcher.platform')
+    nuxt.options.alias[networkDispatcherAlias] = nodeNetworkDispatcherPath
+    nuxt.hook('nitro:init', (nitro) => {
+      nitro.options.alias[networkDispatcherAlias] = nitro.options.node
+        ? nodeNetworkDispatcherPath
+        : platformNetworkDispatcherPath
+    })
     await setupNitroRuntimeCompatibility(nuxt)
     if (nuxt.options.dev) {
       setupDevtools(nuxt, { standalone: config._standaloneDevtools })

--- a/packages/script/src/runtime/server/utils/network-dispatcher.node.ts
+++ b/packages/script/src/runtime/server/utils/network-dispatcher.node.ts
@@ -1,0 +1,23 @@
+import type { CreateNetworkDispatcher, NetworkAddress } from './network-host'
+import { lookup } from 'node:dns'
+import { Agent, fetch } from 'undici'
+
+export const createNetworkDispatcher: CreateNetworkDispatcher = async (createLookup, resolveHostnameOverride) => {
+  const resolveHostname = resolveHostnameOverride || ((hostname, callback) => {
+    lookup(hostname, { all: true, verbatim: true }, (error, addresses) => {
+      callback(error, addresses as NetworkAddress[])
+    })
+  })
+  const dispatcher = new Agent({
+    connect: {
+      lookup: createLookup(resolveHostname),
+    },
+  })
+  return {
+    fetch: ((input, init) => fetch(input as string | URL, {
+      ...(init as unknown as NonNullable<Parameters<typeof fetch>[1]>),
+      dispatcher,
+    }) as unknown as Promise<Response>) as typeof globalThis.fetch,
+    close: () => dispatcher.close(),
+  }
+}

--- a/packages/script/src/runtime/server/utils/network-dispatcher.platform.ts
+++ b/packages/script/src/runtime/server/utils/network-dispatcher.platform.ts
@@ -1,0 +1,6 @@
+import type { CreateNetworkDispatcher } from './network-host'
+
+export const createNetworkDispatcher: CreateNetworkDispatcher = async () => ({
+  fetch: globalThis.fetch,
+  close: async () => {},
+})

--- a/packages/script/src/runtime/server/utils/network-host.ts
+++ b/packages/script/src/runtime/server/utils/network-host.ts
@@ -1,21 +1,15 @@
 import type { LookupFunction } from 'node:net'
-import { runtime } from 'std-env'
+import { createNetworkDispatcher } from '#nuxt-scripts/network-dispatcher'
+import { isPublicNetworkHostname } from './network-hostname'
 
-const LOCAL_HOST_SUFFIXES = [
-  'home',
-  'internal',
-  'lan',
-  'local',
-  'localdomain',
-  'localhost',
-]
+export { isPublicNetworkHostname } from './network-hostname'
 
-interface NetworkAddress {
+export interface NetworkAddress {
   address: string
   family: 4 | 6
 }
 
-type ResolveNetworkHostname = (
+export type ResolveNetworkHostname = (
   hostname: string,
   callback: (error: Error | null, addresses: NetworkAddress[]) => void,
 ) => void
@@ -30,6 +24,11 @@ export interface PublicNetworkDispatcher {
   fetch: typeof globalThis.fetch
   close: () => Promise<void>
 }
+
+export type CreateNetworkDispatcher = (
+  createLookup: (resolveHostname: ResolveNetworkHostname) => LookupFunction,
+  resolveHostnameOverride?: ResolveNetworkHostname,
+) => Promise<PublicNetworkDispatcher>
 
 /** Close a dispatcher without replacing the request or stream error already in flight. */
 export async function closePublicNetworkDispatcher(
@@ -46,68 +45,6 @@ export async function closePublicNetworkDispatcher(
     }
     throw cleanupError
   })
-}
-
-function parseIPv4(hostname: string): [number, number, number, number] | undefined {
-  const parts = hostname.split('.')
-  if (parts.length !== 4 || parts.some(part => !/^\d{1,3}$/.test(part)))
-    return
-  const octets = parts.map(Number)
-  return octets.every(octet => octet >= 0 && octet <= 255)
-    ? octets as [number, number, number, number]
-    : undefined
-}
-
-function isPublicIPv4([a, b, c]: [number, number, number, number]): boolean {
-  return a !== 0
-    && a !== 10
-    && a !== 127
-    && !(a === 100 && b >= 64 && b <= 127)
-    && !(a === 169 && b === 254)
-    && !(a === 172 && b >= 16 && b <= 31)
-    && !(a === 192 && b === 0 && c === 0)
-    && !(a === 192 && b === 0 && c === 2)
-    && !(a === 192 && b === 88 && c === 99)
-    && !(a === 192 && b === 168)
-    && !(a === 198 && (b === 18 || b === 19))
-    && !(a === 198 && b === 51 && c === 100)
-    && !(a === 203 && b === 0 && c === 113)
-    && a < 224
-}
-
-function isPublicIPv6(hostname: string): boolean {
-  const groups = hostname.split(':')
-  const firstGroup = Number.parseInt(groups[0] || '0', 16)
-  if (!Number.isInteger(firstGroup) || firstGroup < 0x2000 || firstGroup > 0x3FFF)
-    return false
-  // Documentation, Teredo, and 6to4 ranges can encode or route to non-public targets.
-  const secondGroup = Number.parseInt(groups[1] || '0', 16)
-  return !(firstGroup === 0x2001 && (secondGroup === 0 || secondGroup === 0xDB8))
-    && firstGroup !== 0x2002
-}
-
-/** Reject hostnames that directly address local, private, link-local, or reserved networks. */
-export function isPublicNetworkHostname(input: string): boolean {
-  const hostname = input
-    .trim()
-    .toLowerCase()
-    .replace(/^\[|\]$/g, '')
-    .split('%', 1)[0]!
-    .replace(/\.$/, '')
-  if (!hostname)
-    return false
-
-  const ipv4 = parseIPv4(hostname)
-  if (ipv4)
-    return isPublicIPv4(ipv4)
-  if (hostname.includes(':'))
-    return isPublicIPv6(hostname)
-
-  const labels = hostname.split('.')
-  if (labels.length < 2)
-    return false
-  const suffix = labels.at(-1)!
-  return !LOCAL_HOST_SUFFIXES.includes(suffix)
 }
 
 /** Resolve once inside the socket connection, reject mixed/private answers, then pin the selected address. */
@@ -142,44 +79,9 @@ export function createPublicNetworkLookup(resolveHostname: ResolveNetworkHostnam
   return networkLookup as LookupFunction
 }
 
-/** Create a Node fetch dispatcher whose socket lookup validates and pins every DNS answer. */
+/** Create a host fetch implementation that validates and pins every DNS answer when Node permits it. */
 export async function createPublicNetworkDispatcher(resolveHostnameOverride?: ResolveNetworkHostname): Promise<PublicNetworkDispatcher> {
-  if (runtime !== 'node')
-    return { fetch: globalThis.fetch, close: async () => {} }
-
-  // Loaded only on Node. Other runtimes keep their platform fetch behavior;
-  // call sites still reject direct non-public hostnames before fetching.
-  // The root `undici` entry eagerly loads its mock formatter, which imports
-  // `node:console`. Workerd then installs a Console whose createTask method
-  // throws. Load its dispatcher and fetch-only entry so Worker bundles stay
-  // clear of that Node module.
-  // @ts-expect-error Undici does not publish declarations for internal modules.
-  const { default: Agent } = await import('undici/lib/dispatcher/agent.js') as {
-    default: typeof import('undici').Agent
-  }
-  // @ts-expect-error Undici does not publish declarations for its fetch-only entry.
-  const { fetch } = await import('undici/index-fetch.js') as {
-    fetch: typeof import('undici').fetch
-  }
-  let resolveHostname = resolveHostnameOverride
-  if (!resolveHostname) {
-    const { lookup } = await import('node:dns')
-    resolveHostname = (hostname, callback) => lookup(hostname, { all: true, verbatim: true }, (error, addresses) => {
-      callback(error, addresses as NetworkAddress[])
-    })
-  }
-  const dispatcher = new Agent({
-    connect: {
-      lookup: createPublicNetworkLookup(resolveHostname),
-    },
-  })
-  return {
-    fetch: ((input, init) => fetch(input as string | URL, {
-      ...(init as unknown as NonNullable<Parameters<typeof fetch>[1]>),
-      dispatcher,
-    }) as unknown as Promise<Response>) as typeof globalThis.fetch,
-    close: () => dispatcher.close(),
-  }
+  return createNetworkDispatcher(createPublicNetworkLookup, resolveHostnameOverride)
 }
 
 /** Detect the tagged DNS policy error through fetch/ofetch cause wrappers. */

--- a/packages/script/src/runtime/server/utils/network-host.ts
+++ b/packages/script/src/runtime/server/utils/network-host.ts
@@ -149,7 +149,18 @@ export async function createPublicNetworkDispatcher(resolveHostnameOverride?: Re
 
   // Loaded only on Node. Other runtimes keep their platform fetch behavior;
   // call sites still reject direct non-public hostnames before fetching.
-  const { Agent, fetch } = await import('undici')
+  // The root `undici` entry eagerly loads its mock formatter, which imports
+  // `node:console`. Workerd then installs a Console whose createTask method
+  // throws. Load its dispatcher and fetch-only entry so Worker bundles stay
+  // clear of that Node module.
+  // @ts-expect-error Undici does not publish declarations for internal modules.
+  const { default: Agent } = await import('undici/lib/dispatcher/agent.js') as {
+    default: typeof import('undici').Agent
+  }
+  // @ts-expect-error Undici does not publish declarations for its fetch-only entry.
+  const { fetch } = await import('undici/index-fetch.js') as {
+    fetch: typeof import('undici').fetch
+  }
   let resolveHostname = resolveHostnameOverride
   if (!resolveHostname) {
     const { lookup } = await import('node:dns')

--- a/packages/script/src/runtime/server/utils/network-hostname.ts
+++ b/packages/script/src/runtime/server/utils/network-hostname.ts
@@ -1,0 +1,67 @@
+const LOCAL_HOST_SUFFIXES = [
+  'home',
+  'internal',
+  'lan',
+  'local',
+  'localdomain',
+  'localhost',
+]
+function parseIPv4(hostname: string): [number, number, number, number] | undefined {
+  const parts = hostname.split('.')
+  if (parts.length !== 4 || parts.some(part => !/^\d{1,3}$/.test(part)))
+    return
+  const octets = parts.map(Number)
+  return octets.every(octet => octet >= 0 && octet <= 255)
+    ? octets as [number, number, number, number]
+    : undefined
+}
+function isPublicIPv4([a, b, c]: [number, number, number, number]): boolean {
+  return a !== 0
+    && a !== 10
+    && a !== 127
+    && !(a === 100 && b >= 64 && b <= 127)
+    && !(a === 169 && b === 254)
+    && !(a === 172 && b >= 16 && b <= 31)
+    && !(a === 192 && b === 0 && c === 0)
+    && !(a === 192 && b === 0 && c === 2)
+    && !(a === 192 && b === 88 && c === 99)
+    && !(a === 192 && b === 168)
+    && !(a === 198 && (b === 18 || b === 19))
+    && !(a === 198 && b === 51 && c === 100)
+    && !(a === 203 && b === 0 && c === 113)
+    && a < 224
+}
+function isPublicIPv6(hostname: string): boolean {
+  const groups = hostname.split(':')
+  const firstGroup = Number.parseInt(groups[0] || '0', 16)
+  if (!Number.isInteger(firstGroup) || firstGroup < 0x2000 || firstGroup > 0x3FFF)
+    return false
+  // Documentation, Teredo, and 6to4 ranges can encode or route to non-public targets.
+  const secondGroup = Number.parseInt(groups[1] || '0', 16)
+  return !(firstGroup === 0x2001 && (secondGroup === 0 || secondGroup === 0xDB8))
+    && firstGroup !== 0x2002
+}
+
+/** Reject hostnames that directly address local, private, link-local, or reserved networks. */
+export function isPublicNetworkHostname(input: string): boolean {
+  const hostname = input
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '')
+    .split('%', 1)[0]!
+    .replace(/\.$/, '')
+  if (!hostname)
+    return false
+
+  const ipv4 = parseIPv4(hostname)
+  if (ipv4)
+    return isPublicIPv4(ipv4)
+  if (hostname.includes(':'))
+    return isPublicIPv6(hostname)
+
+  const labels = hostname.split('.')
+  if (labels.length < 2)
+    return false
+  const suffix = labels.at(-1)!
+  return !LOCAL_HOST_SUFFIXES.includes(suffix)
+}

--- a/test/unit/network-host.test.ts
+++ b/test/unit/network-host.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { createNetworkDispatcher as createPlatformNetworkDispatcher } from '../../packages/script/src/runtime/server/utils/network-dispatcher.platform'
 import { createPublicNetworkDispatcher, createPublicNetworkLookup, isPrivateNetworkResolutionError, isPublicNetworkHostname } from '../../packages/script/src/runtime/server/utils/network-host'
 
 describe('public network hostname boundary', () => {
@@ -65,31 +66,11 @@ describe('public network hostname boundary', () => {
     expect(error).toMatchObject({ code: 'ERR_NUXT_SCRIPTS_PRIVATE_ADDRESS' })
   })
 
-  it('creates the Node dispatcher without loading node:console', async () => {
-    const { default: moduleRuntime } = await import('node:module') as typeof import('node:module') & {
-      default: typeof import('node:module') & {
-        _load: (request: string, parent: unknown, isMain: boolean) => unknown
-      }
-    }
-    const mutableModuleRuntime = moduleRuntime as typeof moduleRuntime & {
-      _load: (request: string, parent: unknown, isMain: boolean) => unknown
-    }
-    const originalLoad = mutableModuleRuntime._load
-    mutableModuleRuntime._load = (request, parent, isMain) => {
-      if (request === 'node:console')
-        throw new Error('The Console.createTask method is not implemented')
-      return originalLoad(request, parent, isMain)
-    }
+  it('uses the runtime fetch on platforms without Node dispatchers', async () => {
+    const network = await createPlatformNetworkDispatcher()
 
-    try {
-      const network = await createPublicNetworkDispatcher((_hostname, callback) => callback(null, [
-        { address: '1.1.1.1', family: 4 },
-      ]))
-      await network.close()
-    }
-    finally {
-      mutableModuleRuntime._load = originalLoad
-    }
+    expect(network.fetch).toBe(globalThis.fetch)
+    await expect(network.close()).resolves.toBeUndefined()
   })
 
   it('uses the validated lookup for the actual Node fetch connection', async () => {

--- a/test/unit/network-host.test.ts
+++ b/test/unit/network-host.test.ts
@@ -65,6 +65,33 @@ describe('public network hostname boundary', () => {
     expect(error).toMatchObject({ code: 'ERR_NUXT_SCRIPTS_PRIVATE_ADDRESS' })
   })
 
+  it('creates the Node dispatcher without loading node:console', async () => {
+    const { default: moduleRuntime } = await import('node:module') as typeof import('node:module') & {
+      default: typeof import('node:module') & {
+        _load: (request: string, parent: unknown, isMain: boolean) => unknown
+      }
+    }
+    const mutableModuleRuntime = moduleRuntime as typeof moduleRuntime & {
+      _load: (request: string, parent: unknown, isMain: boolean) => unknown
+    }
+    const originalLoad = mutableModuleRuntime._load
+    mutableModuleRuntime._load = (request, parent, isMain) => {
+      if (request === 'node:console')
+        throw new Error('The Console.createTask method is not implemented')
+      return originalLoad(request, parent, isMain)
+    }
+
+    try {
+      const network = await createPublicNetworkDispatcher((_hostname, callback) => callback(null, [
+        { address: '1.1.1.1', family: 4 },
+      ]))
+      await network.close()
+    }
+    finally {
+      mutableModuleRuntime._load = originalLoad
+    }
+  })
+
   it('uses the validated lookup for the actual Node fetch connection', async () => {
     const network = await createPublicNetworkDispatcher((_hostname, callback) => callback(null, [
       { address: '127.0.0.1', family: 4 },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
             'unhead/scripts': new URL('./packages/script/node_modules/unhead/dist/scripts.mjs', import.meta.url).pathname,
             '#nuxt-scripts/h3': 'h3',
             '#nuxt-scripts/nitro': new URL('./test/unit/__mocks__/empty.ts', import.meta.url).pathname,
+            '#nuxt-scripts/network-dispatcher': new URL('./packages/script/src/runtime/server/utils/network-dispatcher.node.ts', import.meta.url).pathname,
             // Virtual emitted by the Nuxt module at build time; unit tests
             // mock it via `vi.mock('#build/nuxt-scripts-snippets')`, but the
             // import must first resolve to *something* the bundler accepts.


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #859

### 📚 Description

Nuxt Scripts imported Undici's Node dispatcher from shared runtime code. Nitro then bundled Undici's mock formatter into Cloudflare Workers, which imported `node:console` and exposed Workerd's throwing `console.createTask` to Hookable.

Select the dispatcher after Nitro resolves the host. Node keeps the DNS-pinned Undici fetch. Other runtimes use their platform fetch and never bundle Undici.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).