### PR TITLE
fix(gtm): don't declare `dataLayer` on the global `Window` (1.x backport)

### DIFF
--- a/packages/script/src/runtime/registry/google-tag-manager.ts
+++ b/packages/script/src/runtime/registry/google-tag-manager.ts
@@ -72,9 +72,17 @@ export interface GoogleTagManagerApi {
 
 /**
  * Enhanced window type with GTM
+ *
+ * `dataLayer` is deliberately NOT declared globally. Its name is configurable through the
+ * `l` / `dataLayer` options, so `window.dataLayer` is not guaranteed to exist, and declaring it
+ * here makes this package irreconcilable with any other package that declares `Window.dataLayer`
+ * (for example `@gtm-support/core`, used by `@gtm-support/vue-gtm`): the two declarations cannot
+ * merge, so consumers of both get an unsuppressable TS2430 at every one of their own `Window`
+ * augmentations. Read it through the typed proxy returned by `useScriptGoogleTagManager()`
+ * instead, which is also the only access path that respects a custom dataLayer name.
  */
 declare global {
-  interface Window extends GoogleTagManagerApi {}
+  interface Window extends Pick<GoogleTagManagerApi, 'google_tag_manager'> {}
 }
 
 export { GoogleTagManagerOptions }

--- a/test/types/global-window.test-d.ts
+++ b/test/types/global-window.test-d.ts
@@ -1,0 +1,31 @@
+import type { GoogleTagManagerApi } from '../../packages/script/src/runtime/registry/google-tag-manager'
+import { describe, expectTypeOf, it } from 'vitest'
+
+/**
+ * Regression guard for #852.
+ *
+ * `@gtm-support/core` (the engine behind `@gtm-support/vue-gtm`) declares
+ * `Window.dataLayer?: DataLayerObject[]`. Interface declarations merge, so if this package
+ * also declares `dataLayer` on the global `Window`, the merged `Window` fails this package's
+ * own `extends` clause. TypeScript then reports TS2430 at every one of the consumer's own
+ * `Window` augmentations, which the consumer cannot suppress.
+ *
+ * `dataLayer` must stay off the global `Window`. Its name is configurable through the
+ * `l` / `dataLayer` options anyway, so `window.dataLayer` was never guaranteed to exist.
+ * The proxy returned by `useScriptGoogleTagManager()` is the supported access path.
+ */
+describe('global `Window` augmentation', () => {
+  it('does not declare `dataLayer`', () => {
+    expectTypeOf<'dataLayer' extends keyof Window ? true : false>().toEqualTypeOf<false>()
+  })
+
+  it('keeps `google_tag_manager` declared', () => {
+    // `useScriptGoogleTagManager`'s `use()` reads `window.google_tag_manager` directly.
+    expectTypeOf<Window['google_tag_manager']>().toEqualTypeOf<GoogleTagManagerApi['google_tag_manager']>()
+  })
+
+  it('still types `dataLayer` on the GTM proxy API', () => {
+    expectTypeOf<GoogleTagManagerApi['dataLayer']>().not.toBeAny()
+    expectTypeOf<GoogleTagManagerApi['dataLayer']['push']>().toBeCallableWith({ event: 'test' })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Backport of #855 to the `1.x` release line. Fixes #852 on `1.x`.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Straight cherry-pick of a6d763ef, no conflicts and no drift. `1.x` still exports the deprecated `GoogleTagManagerConsent` alias that `main` dropped, but the cherry-pick does not touch that line.

The GTM registry augmented the global `Window` with the whole `GoogleTagManagerApi`, including a required `dataLayer`. That made the package irreconcilable with any other package that declares `Window.dataLayer`, most commonly `@gtm-support/core`, the engine behind `@gtm-support/vue-gtm`. The two declarations merge into one `Window`, which then fails this package's own `extends` clause. TypeScript reports TS2430 at every one of the consumer's own `Window` augmentations, and the consumer cannot suppress it because neither declaration is theirs.

Making `dataLayer` optional does not fix it. `Array<T>.push` is `(...items: T[]) => number`, while `DataLayerPush`'s first overload starts with `(command: string, ...)`, so a foreign element type stays incompatible.

The fix declares only the member that is genuinely global and unambiguous:

```diff
-  interface Window extends GoogleTagManagerApi {}
+  interface Window extends Pick<GoogleTagManagerApi, 'google_tag_manager'> {}
```

`GoogleTagManagerApi` itself is unchanged, so `useScriptGoogleTagManager()` and its proxy keep `dataLayer` typed. The registry never read the global declaration for `dataLayer` anyway: it reads `(window as any)[dataLayerName]`, because the name is configurable through the `l` / `dataLayer` options. `window.google_tag_manager` is read directly in `use()`, which is why that member stays.

This is a type-level change only. Zero runtime bytes.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests.

`test/types/global-window.test-d.ts` guards the regression. On this branch it fails against the old declaration and passes against the fix.

On `1.x`: `pnpm vitest run --project typecheck` passes (46 tests, no type errors), `pnpm typecheck` clean, `pnpm lint` clean.
