### PR TITLE
perf: drop undici from the Node network dispatcher

### DIFF
--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -142,7 +142,6 @@
     "std-env": "catalog:",
     "ufo": "catalog:",
     "ultrahtml": "catalog:",
-    "undici": "catalog:",
     "unplugin": "catalog:",
     "unstorage": "catalog:",
     "valibot": "catalog:"

--- a/packages/script/src/runtime/server/utils/network-dispatcher.node.ts
+++ b/packages/script/src/runtime/server/utils/network-dispatcher.node.ts
@@ -1,6 +1,168 @@
+import type { IncomingMessage, RequestOptions } from 'node:http'
 import type { CreateNetworkDispatcher, NetworkAddress } from './network-host'
 import { lookup } from 'node:dns'
-import { Agent, fetch } from 'undici'
+import { Agent as HttpAgent, request as httpRequest } from 'node:http'
+import { Agent as HttpsAgent, request as httpsRequest } from 'node:https'
+import { Readable } from 'node:stream'
+import { createBrotliDecompress, createGunzip, createInflate, constants as zlibConstants } from 'node:zlib'
+
+/**
+ * Node has no public API for a custom DNS lookup on `globalThis.fetch`, and the proxy
+ * needs one: the address is validated inside the socket connection, so a rebind between
+ * the check and the connect cannot slip past. So this is a fetch built on `node:http`,
+ * which does accept a lookup, rather than a fetch with an undici `Agent` bolted on.
+ * Keeping undici out saves roughly 1.6 MB from a traced Node server build.
+ */
+
+/** Statuses that must carry a null body, per fetch. */
+const NULL_BODY_STATUS = new Set([101, 103, 204, 205, 304])
+
+const ACCEPTED_ENCODINGS = 'gzip, deflate, br'
+
+function toHeaderRecord(headers: HeadersInit | undefined): Record<string, string | string[]> {
+  const record: Record<string, string | string[]> = {}
+  if (!headers)
+    return record
+  const append = (name: string, value: string) => {
+    const key = name.toLowerCase()
+    const existing = record[key]
+    if (existing === undefined)
+      record[key] = value
+    else if (Array.isArray(existing))
+      existing.push(value)
+    else
+      record[key] = [existing, value]
+  }
+  if (headers instanceof Headers) {
+    headers.forEach((value, name) => append(name, value))
+  }
+  else if (Array.isArray(headers)) {
+    for (const [name, value] of headers) append(name, value)
+  }
+  else {
+    for (const [name, value] of Object.entries(headers)) append(name, String(value))
+  }
+  return record
+}
+
+/** Node exposes duplicate response headers only through `rawHeaders`, and `set-cookie` needs them. */
+function toResponseHeaders(raw: string[]): Headers {
+  const headers = new Headers()
+  for (let i = 0; i < raw.length; i += 2)
+    headers.append(raw[i]!, raw[i + 1]!)
+  return headers
+}
+
+/**
+ * Decode the body the way fetch does, so callers see plain bytes and can keep treating
+ * `content-encoding` as a header to strip rather than a body format to handle.
+ */
+function decodeBody(response: IncomingMessage): Readable {
+  const encodings = String(response.headers['content-encoding'] || '')
+    .split(',')
+    .map(encoding => encoding.trim().toLowerCase())
+    .filter(Boolean)
+    .reverse()
+
+  // Tolerate an upstream that ends the stream without a proper trailer, the way fetch does.
+  const flush = { finishFlush: zlibConstants.Z_SYNC_FLUSH }
+  let stream: Readable = response
+  for (const encoding of encodings) {
+    if (encoding === 'gzip' || encoding === 'x-gzip')
+      stream = stream.pipe(createGunzip(flush))
+    else if (encoding === 'deflate' || encoding === 'x-deflate')
+      stream = stream.pipe(createInflate(flush))
+    else if (encoding === 'br')
+      stream = stream.pipe(createBrotliDecompress())
+    else
+      break // identity, or an encoding we do not decode; hand the bytes through untouched
+  }
+  return stream
+}
+
+/** Byte length of a body fetch would send with a `content-length`, or null when it streams. */
+function knownBodyLength(body: BodyInit | null | undefined): number | null {
+  if (body === undefined || body === null)
+    return null
+  if (typeof body === 'string')
+    return Buffer.byteLength(body)
+  if (body instanceof URLSearchParams)
+    return Buffer.byteLength(body.toString())
+  if (ArrayBuffer.isView(body))
+    return body.byteLength
+  if (body instanceof ArrayBuffer)
+    return body.byteLength
+  return null
+}
+
+function writeRequestBody(request: ReturnType<typeof httpRequest>, body: BodyInit | null | undefined): void {
+  if (body === undefined || body === null) {
+    request.end()
+    return
+  }
+  if (typeof body === 'string') {
+    request.end(body)
+    return
+  }
+  if (body instanceof ReadableStream) {
+    Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]).pipe(request)
+    return
+  }
+  if (body instanceof URLSearchParams) {
+    request.end(body.toString())
+    return
+  }
+  if (ArrayBuffer.isView(body)) {
+    request.end(Buffer.from(body.buffer, body.byteOffset, body.byteLength))
+    return
+  }
+  if (body instanceof ArrayBuffer) {
+    request.end(Buffer.from(body))
+    return
+  }
+  request.destroy(new TypeError(`Unsupported proxy request body of type ${Object.prototype.toString.call(body)}`))
+}
+
+function requestThroughAgent(
+  url: URL,
+  init: RequestInit,
+  agents: { http: HttpAgent, https: HttpsAgent },
+): Promise<Response> {
+  const isSecure = url.protocol === 'https:'
+  const headers = toHeaderRecord(init.headers)
+  if (!('accept-encoding' in headers))
+    headers['accept-encoding'] = ACCEPTED_ENCODINGS
+
+  const method = (init.method || 'GET').toUpperCase()
+  if (headers['content-length'] === undefined) {
+    const length = knownBodyLength(init.body)
+    if (length !== null)
+      headers['content-length'] = String(length)
+  }
+
+  const options: RequestOptions = {
+    method,
+    headers,
+    agent: isSecure ? agents.https : agents.http,
+    signal: init.signal ?? undefined,
+  }
+
+  return new Promise<Response>((resolve, reject) => {
+    const request = (isSecure ? httpsRequest : httpRequest)(url, options, (response) => {
+      const status = response.statusCode ?? 502
+      const body = NULL_BODY_STATUS.has(status) || method === 'HEAD'
+        ? null
+        : Readable.toWeb(decodeBody(response)) as ReadableStream<Uint8Array>
+      resolve(new Response(body, {
+        status,
+        statusText: response.statusMessage || '',
+        headers: toResponseHeaders(response.rawHeaders),
+      }))
+    })
+    request.on('error', reject)
+    writeRequestBody(request, init.body)
+  })
+}
 
 export const createNetworkDispatcher: CreateNetworkDispatcher = async (createLookup, resolveHostnameOverride) => {
   const resolveHostname = resolveHostnameOverride || ((hostname, callback) => {
@@ -8,16 +170,20 @@ export const createNetworkDispatcher: CreateNetworkDispatcher = async (createLoo
       callback(error, addresses as NetworkAddress[])
     })
   })
-  const dispatcher = new Agent({
-    connect: {
-      lookup: createLookup(resolveHostname),
-    },
-  })
+  const pinnedLookup = createLookup(resolveHostname)
+  const agents = {
+    http: new HttpAgent({ keepAlive: true, lookup: pinnedLookup }),
+    https: new HttpsAgent({ keepAlive: true, lookup: pinnedLookup }),
+  }
   return {
-    fetch: ((input, init) => fetch(input as string | URL, {
-      ...(init as unknown as NonNullable<Parameters<typeof fetch>[1]>),
-      dispatcher,
-    }) as unknown as Promise<Response>) as typeof globalThis.fetch,
-    close: () => dispatcher.close(),
+    fetch: ((input, init) => requestThroughAgent(
+      new URL(input instanceof Request ? input.url : String(input)),
+      init ?? {},
+      agents,
+    )) as typeof globalThis.fetch,
+    close: async () => {
+      agents.http.destroy()
+      agents.https.destroy()
+    },
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,9 +162,6 @@ catalogs:
     unbuild:
       specifier: ^3.6.1
       version: 3.6.1
-    undici:
-      specifier: ^8.10.0
-      version: 8.10.0
     unhead:
       specifier: ^3.3.1
       version: 3.3.1
@@ -460,9 +457,6 @@ importers:
       ultrahtml:
         specifier: 'catalog:'
         version: 1.7.0
-      undici:
-        specifier: 'catalog:'
-        version: 8.10.0
       unplugin:
         specifier: 'catalog:'
         version: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.4)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
@@ -6716,10 +6710,6 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
-
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
-    engines: {node: '>=22.19.0'}
 
   undici@8.9.0:
     resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
@@ -15015,8 +15005,6 @@ snapshots:
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.4)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   undici-types@8.3.0: {}
-
-  undici@8.10.0: {}
 
   undici@8.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -100,7 +100,6 @@ catalog:
   ufo: ^1.6.4
   ultrahtml: ^1.7.0
   unbuild: ^3.6.1
-  undici: ^8.10.0
   unhead: ^3.3.1
   unimport: ^6.4.0
   unplugin: ^3.3.0

--- a/test/unit/network-dispatcher-node.test.ts
+++ b/test/unit/network-dispatcher-node.test.ts
@@ -1,0 +1,154 @@
+import type { AddressInfo } from 'node:net'
+import type { PublicNetworkDispatcher, ResolveNetworkHostname } from '../../packages/script/src/runtime/server/utils/network-host'
+import { createServer } from 'node:http'
+import { gzipSync } from 'node:zlib'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { createNetworkDispatcher } from '../../packages/script/src/runtime/server/utils/network-dispatcher.node'
+
+let requests: Array<{ method: string, url: string, headers: Record<string, string | string[] | undefined>, body: string }> = []
+let origin: string
+const server = createServer((req, res) => {
+  const chunks: Buffer[] = []
+  req.on('data', chunk => chunks.push(chunk))
+  req.on('end', () => {
+    requests.push({
+      method: req.method!,
+      url: req.url!,
+      headers: req.headers,
+      body: Buffer.concat(chunks).toString(),
+    })
+    const path = req.url!
+    if (path === '/gzip') {
+      res.writeHead(200, { 'content-type': 'text/plain', 'content-encoding': 'gzip' })
+      res.end(gzipSync(Buffer.from('compressed payload')))
+      return
+    }
+    if (path === '/redirect') {
+      res.writeHead(302, { location: 'https://example.com/elsewhere' })
+      res.end()
+      return
+    }
+    if (path === '/cookies') {
+      res.writeHead(200, { 'set-cookie': ['a=1', 'b=2'] })
+      res.end('ok')
+      return
+    }
+    if (path === '/empty') {
+      res.writeHead(204)
+      res.end()
+      return
+    }
+    res.writeHead(201, { 'content-type': 'application/json', 'x-echo': path })
+    res.end(JSON.stringify({ received: Buffer.concat(chunks).toString() }))
+  })
+})
+
+/** Resolve every hostname to the loopback test server, bypassing the public-address policy. */
+function loopbackDispatcher(): Promise<PublicNetworkDispatcher> {
+  return createNetworkDispatcher(() => ((_hostname: string, options: any, callback: any) => (
+    options?.all
+      ? callback(null, [{ address: '127.0.0.1', family: 4 }])
+      : callback(null, '127.0.0.1', 4)
+  )) as any)
+}
+
+/** A dispatcher whose lookup always rejects, standing in for the private-address policy. */
+function rejectingDispatcher(): Promise<PublicNetworkDispatcher> {
+  const failing: ResolveNetworkHostname = (_hostname, callback) =>
+    callback(Object.assign(new Error('blocked'), { code: 'ERR_NUXT_SCRIPTS_PRIVATE_ADDRESS' }), [])
+  return createNetworkDispatcher(
+    resolve => ((_hostname: string, _options: any, callback: any) => resolve(_hostname, error => callback(error, ''))) as any,
+    failing,
+  )
+}
+
+let dispatcher: PublicNetworkDispatcher
+
+beforeAll(async () => {
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  origin = `http://cdn.example.com:${(server.address() as AddressInfo).port}`
+  dispatcher = await loopbackDispatcher()
+})
+
+afterEach(() => {
+  requests = []
+})
+
+afterAll(async () => {
+  await dispatcher.close()
+  await new Promise<void>(resolve => server.close(() => resolve()))
+})
+
+describe('node network dispatcher', () => {
+  it('sends the request through the pinned lookup and returns the response', async () => {
+    const response = await dispatcher.fetch(`${origin}/hello`)
+    expect(response.status).toBe(201)
+    expect(response.headers.get('x-echo')).toBe('/hello')
+    expect(await response.json()).toEqual({ received: '' })
+    expect(requests[0]!.headers.host).toBe(new URL(origin).host)
+  })
+
+  it('decompresses a gzip response body', async () => {
+    const response = await dispatcher.fetch(`${origin}/gzip`)
+    expect(await response.text()).toBe('compressed payload')
+  })
+
+  it('requests compressed encodings unless the caller set its own', async () => {
+    await dispatcher.fetch(`${origin}/a`)
+    expect(requests[0]!.headers['accept-encoding']).toBe('gzip, deflate, br')
+    await dispatcher.fetch(`${origin}/b`, { headers: { 'accept-encoding': 'identity' } })
+    expect(requests[1]!.headers['accept-encoding']).toBe('identity')
+  })
+
+  it('sends a string body with a content-length', async () => {
+    await dispatcher.fetch(`${origin}/post`, { method: 'POST', body: 'hello=1' })
+    expect(requests[0]!.method).toBe('POST')
+    expect(requests[0]!.body).toBe('hello=1')
+    expect(requests[0]!.headers['content-length']).toBe('7')
+  })
+
+  it('streams a ReadableStream body', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk-one|'))
+        controller.enqueue(new TextEncoder().encode('chunk-two'))
+        controller.close()
+      },
+    })
+    const response = await dispatcher.fetch(`${origin}/stream`, { method: 'POST', body, duplex: 'half' } as RequestInit)
+    expect(await response.json()).toEqual({ received: 'chunk-one|chunk-two' })
+    expect(requests[0]!.headers['content-length']).toBeUndefined()
+  })
+
+  it('does not follow redirects', async () => {
+    const response = await dispatcher.fetch(`${origin}/redirect`)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('https://example.com/elsewhere')
+  })
+
+  it('preserves repeated set-cookie headers', async () => {
+    const response = await dispatcher.fetch(`${origin}/cookies`)
+    expect(response.headers.getSetCookie()).toEqual(['a=1', 'b=2'])
+  })
+
+  it('returns a null body for a 204', async () => {
+    const response = await dispatcher.fetch(`${origin}/empty`)
+    expect(response.status).toBe(204)
+    expect(response.body).toBeNull()
+  })
+
+  it('forwards a caller abort', async () => {
+    const controller = new AbortController()
+    const pending = dispatcher.fetch(`${origin}/slow`, { signal: controller.signal })
+    controller.abort()
+    await expect(pending).rejects.toThrow()
+  })
+
+  it('surfaces the lookup rejection so the private-address policy is detectable', async () => {
+    const blocked = await rejectingDispatcher()
+    await expect(blocked.fetch('http://blocked.example.com/')).rejects.toMatchObject({
+      code: 'ERR_NUXT_SCRIPTS_PRIVATE_ADDRESS',
+    })
+    await blocked.close()
+  })
+})


### PR DESCRIPTION
### 📚 Description

`undici` is 1.6 MB of a 4.6 MB traced server build on `test/fixtures/basic`, a third of the output. Any app using an embed or the proxy pays it.

We used it for one thing:

```js
const dispatcher = new Agent({ connect: { lookup: createLookup(resolveHostname) } })
```

That lookup is the SSRF guard from #840. Resolving inside the socket connection is the point: a rebind cannot land between the address check and the connect. Node's global `fetch` has no way to accept it, hence the dependency.

`node:http` does accept a lookup, so the pin survives without undici. The fetch surface the proxy actually uses is reimplemented on top of it:

- content encoding decoded like fetch does, so `content-encoding` stays a header the proxy strips rather than a body format callers must handle
- repeated `set-cookie` preserved by reading `rawHeaders`
- null body on 204, 205, 304, and HEAD
- streamed request bodies, `content-length` set only when the length is known
- caller aborts forwarded through the request `signal`
- redirects never followed, which is what every caller already asked for with `redirect: 'manual'`

Traced server output for `test/fixtures/basic` goes 4.6 MB to 3.1 MB.

Non-Node presets are untouched. `network-dispatcher.platform.ts` still hands back `globalThis.fetch`, since a worker has no lookup hook to pin anyway.

One thing I want a second opinion on: I kept `accept-encoding` to `gzip, deflate, br` and left zstd out, so nothing arrives in a format we do not decode. Node can decode it now, so we could advertise it, but I would rather do that deliberately than by accident.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).