### PR TITLE
fix(carbon-ads): keep the script id resolvable after unmount

### DIFF
--- a/packages/script/src/runtime/components/ScriptCarbonAds.vue
+++ b/packages/script/src/runtime/components/ScriptCarbonAds.vue
@@ -26,7 +26,7 @@ defineSlots<{
 }>()
 
 const attrId = `_carbonads_js`
-const carbonadsEl = ref<HTMLElement | null>(import.meta.client ? document.getElementById(attrId) : null)
+const carbonadsEl = ref<HTMLElement | null>(null)
 // syncs to useScript status
 const status = ref('awaitingLoad')
 let scriptEl: HTMLScriptElement | undefined
@@ -56,6 +56,8 @@ function loadCarbon() {
       emit('ready', script)
     }
   }
+  // carbon.js resolves #_carbonads_js by id, so only one may exist at a time
+  document.getElementById(attrId)?.remove()
   carbonadsEl.value.appendChild(script)
 }
 
@@ -82,7 +84,9 @@ onBeforeUnmount(() => {
   if (scriptEl) {
     scriptEl.onload = null
     scriptEl.onerror = null
-    scriptEl.remove()
+    // a pending carbon.js ad callback reads #_carbonads_js.src unguarded, so park
+    // the already-executed script in <head> rather than removing it
+    document.head.appendChild(scriptEl)
     scriptEl = undefined
   }
 })

--- a/test/nuxt-runtime/script-component-lifecycle.nuxt.test.ts
+++ b/test/nuxt-runtime/script-component-lifecycle.nuxt.test.ts
@@ -33,6 +33,8 @@ describe('script component lifecycle', () => {
   afterEach(() => {
     for (const wrapper of wrappers.splice(0))
       wrapper.unmount()
+    for (const el of document.querySelectorAll('#_carbonads_js'))
+      el.remove()
     if (lemonSqueezyDescriptor)
       Object.defineProperty(window, 'LemonSqueezy', lemonSqueezyDescriptor)
     else
@@ -49,6 +51,37 @@ describe('script component lifecycle', () => {
     wrapper.unmount()
 
     expect(removeRoot).not.toHaveBeenCalled()
+  })
+
+  // carbon.js reads `document.getElementById('_carbonads_js').src` from its own
+  // async ad callback, unguarded, so the id must outlive the component.
+  it('keeps the carbon script resolvable by id after unmount', () => {
+    const wrapper = mount(ScriptCarbonAds, {
+      attachTo: document.body,
+      props: { serve: 'CW7DTKJL', placement: 'unlighthousedev', format: 'cover' },
+    })
+    wrappers.push(wrapper)
+
+    wrapper.unmount()
+
+    const readServe = () => new URL(document.getElementById('_carbonads_js')!.getAttribute('src')!, 'https://x.test').searchParams.get('serve')
+    expect(readServe()).toBe('CW7DTKJL')
+  })
+
+  it('replaces the parked script when a new instance mounts', () => {
+    const first = mount(ScriptCarbonAds, {
+      attachTo: document.body,
+      props: { serve: 'CW7DTKJL', placement: 'first', format: 'cover' },
+    })
+    first.unmount()
+    const second = mount(ScriptCarbonAds, {
+      attachTo: document.body,
+      props: { serve: 'CW7DTKJL', placement: 'second', format: 'cover' },
+    })
+    wrappers.push(second)
+
+    expect(document.querySelectorAll('#_carbonads_js')).toHaveLength(1)
+    expect(document.getElementById('_carbonads_js')!.getAttribute('src')).toContain('placement=second')
   })
 
   it('fans Lemon Squeezy events out to every live component', () => {


### PR DESCRIPTION
### 📚 Description

Unmounting `ScriptCarbonAds` crashes the page. carbon.js resolves `#_carbonads_js` from its own pending ad callback and reads `.src` off it with no null check, so removing that element throws inside third-party code where nothing can catch it. Sites that key the ad on the route to refresh it per page hit this on every navigation.

The root ref was also seeded from `document.getElementById('_carbonads_js')`, which is the script's id rather than a container. Every other registry component starts that ref at `null`.

Open question: two instances mounted at once still collide on the hardcoded id. Carbon's own code assumes one per page, so I left it alone.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).