### PR TITLE
fix(registry): don't declare the global `Window` via `extends`

### DIFF
--- a/packages/script/src/runtime/registry/ahrefs-analytics.ts
+++ b/packages/script/src/runtime/registry/ahrefs-analytics.ts
@@ -29,7 +29,11 @@ export interface AhrefsAnalyticsApi {
 }
 
 declare global {
-  interface Window extends AhrefsAnalyticsApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    AhrefsAnalytics: AhrefsAnalyticsApi['AhrefsAnalytics']
+  }
 }
 
 /**

--- a/packages/script/src/runtime/registry/calendly.ts
+++ b/packages/script/src/runtime/registry/calendly.ts
@@ -76,7 +76,11 @@ export interface CalendlyApi {
 }
 
 declare global {
-  interface Window extends CalendlyApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    Calendly: CalendlyApi['Calendly']
+  }
 }
 
 const CALENDLY_CSS_KEY = 'nuxt-scripts-calendly-css'

--- a/packages/script/src/runtime/registry/clarity.ts
+++ b/packages/script/src/runtime/registry/clarity.ts
@@ -25,7 +25,11 @@ export interface ClarityApi {
 }
 
 declare global {
-  interface Window extends ClarityApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    clarity: ClarityApi['clarity']
+  }
 }
 
 export type ClarityInput = RegistryScriptInput<typeof ClarityOptions>

--- a/packages/script/src/runtime/registry/cloudflare-web-analytics.ts
+++ b/packages/script/src/runtime/registry/cloudflare-web-analytics.ts
@@ -20,7 +20,11 @@ export interface CloudflareWebAnalyticsApi {
 }
 
 declare global {
-  interface Window extends CloudflareWebAnalyticsApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    __cfBeacon: CloudflareWebAnalyticsApi['__cfBeacon']
+  }
 }
 
 export type CloudflareWebAnalyticsInput = RegistryScriptInput<typeof CloudflareWebAnalyticsOptions>

--- a/packages/script/src/runtime/registry/google-adsense.ts
+++ b/packages/script/src/runtime/registry/google-adsense.ts
@@ -15,7 +15,11 @@ export interface GoogleAdsenseApi {
 }
 
 declare global {
-  interface Window extends GoogleAdsenseApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    adsbygoogle: GoogleAdsenseApi['adsbygoogle']
+  }
 }
 
 /**

--- a/packages/script/src/runtime/registry/google-recaptcha.ts
+++ b/packages/script/src/runtime/registry/google-recaptcha.ts
@@ -19,7 +19,11 @@ export interface GoogleRecaptchaApi {
 }
 
 declare global {
-  interface Window extends GoogleRecaptchaApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    grecaptcha: GoogleRecaptchaApi['grecaptcha']
+  }
 }
 
 export function useScriptGoogleRecaptcha<T extends GoogleRecaptchaApi>(_options?: GoogleRecaptchaInput) {

--- a/packages/script/src/runtime/registry/google-tag-manager.ts
+++ b/packages/script/src/runtime/registry/google-tag-manager.ts
@@ -82,7 +82,11 @@ export interface GoogleTagManagerApi {
  * instead, which is also the only access path that respects a custom dataLayer name.
  */
 declare global {
-  interface Window extends Pick<GoogleTagManagerApi, 'google_tag_manager'> {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    google_tag_manager: GoogleTagManagerApi['google_tag_manager']
+  }
 }
 
 export { GoogleTagManagerOptions }

--- a/packages/script/src/runtime/registry/hotjar.ts
+++ b/packages/script/src/runtime/registry/hotjar.ts
@@ -11,7 +11,10 @@ export interface HotjarApi {
 }
 
 declare global {
-  interface Window extends HotjarApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    hj: HotjarApi['hj']
     _hjSettings: { hjid: number, hjsv?: number }
   }
 }

--- a/packages/script/src/runtime/registry/intercom.ts
+++ b/packages/script/src/runtime/registry/intercom.ts
@@ -34,7 +34,10 @@ export interface IntercomApi {
 }
 
 declare global {
-  interface Window extends IntercomApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    Intercom: IntercomApi['Intercom']
     intercomSettings?: any
   }
 }

--- a/packages/script/src/runtime/registry/leaflet.ts
+++ b/packages/script/src/runtime/registry/leaflet.ts
@@ -13,7 +13,11 @@ export interface LeafletApi {
 }
 
 declare global {
-  interface Window extends LeafletApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    L: LeafletApi['L']
+  }
 }
 
 export function useScriptLeaflet<T extends LeafletApi>(_options?: LeafletInput) {

--- a/packages/script/src/runtime/registry/linkedin-insight.ts
+++ b/packages/script/src/runtime/registry/linkedin-insight.ts
@@ -29,7 +29,10 @@ export interface LinkedInInsightApi {
 }
 
 declare global {
-  interface Window extends LinkedInInsightApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    lintrk: LinkedInInsightApi['lintrk']
     _linkedin_partner_id?: string
     _linkedin_data_partner_ids?: string[]
     _linkedin_event_id?: string

--- a/packages/script/src/runtime/registry/matomo-analytics.ts
+++ b/packages/script/src/runtime/registry/matomo-analytics.ts
@@ -14,7 +14,11 @@ export interface MatomoAnalyticsApi {
 }
 
 declare global {
-  interface Window extends MatomoAnalyticsApi { }
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    _paq: MatomoAnalyticsApi['_paq']
+  }
 }
 
 export interface MatomoConsent {

--- a/packages/script/src/runtime/registry/meta-pixel.ts
+++ b/packages/script/src/runtime/registry/meta-pixel.ts
@@ -44,7 +44,13 @@ export interface MetaPixelApi {
 }
 
 declare global {
-  interface Window extends MetaPixelApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    fbq: MetaPixelApi['fbq']
+    _fbq: MetaPixelApi['_fbq']
+    callMethod?: MetaPixelApi['callMethod']
+  }
 }
 
 export { MetaPixelOptions }

--- a/packages/script/src/runtime/registry/paypal.ts
+++ b/packages/script/src/runtime/registry/paypal.ts
@@ -10,7 +10,10 @@ export interface PayPalApi {
 }
 
 declare global {
-  interface Window extends PayPalApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    paypal: PayPalApi['paypal']
   }
 }
 

--- a/packages/script/src/runtime/registry/reddit-pixel.ts
+++ b/packages/script/src/runtime/registry/reddit-pixel.ts
@@ -17,7 +17,11 @@ export interface RedditPixelApi {
 }
 
 declare global {
-  interface Window extends RedditPixelApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    rdt: RedditPixelApi['rdt']
+  }
 }
 
 export { RedditPixelOptions }

--- a/packages/script/src/runtime/registry/segment.ts
+++ b/packages/script/src/runtime/registry/segment.ts
@@ -31,7 +31,16 @@ interface AnalyticsApi {
 export type SegmentApi = Pick<AnalyticsApi, 'track' | 'page' | 'identify' | 'group' | 'alias' | 'reset'>
 
 declare global {
-  interface Window extends SegmentApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    track: SegmentApi['track']
+    page: SegmentApi['page']
+    identify: SegmentApi['identify']
+    group: SegmentApi['group']
+    alias: SegmentApi['alias']
+    reset: SegmentApi['reset']
+  }
 }
 
 const methods = ['track', 'page', 'identify', 'group', 'alias', 'reset']

--- a/packages/script/src/runtime/registry/snapchat-pixel.ts
+++ b/packages/script/src/runtime/registry/snapchat-pixel.ts
@@ -47,7 +47,13 @@ export interface SnapPixelApi {
 }
 
 declare global {
-  interface Window extends SnapPixelApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    snaptr: SnapPixelApi['snaptr']
+    _snaptr: SnapPixelApi['_snaptr']
+    handleRequest?: SnapPixelApi['handleRequest']
+  }
 }
 export type SnapTrPixelInput = RegistryScriptInput<typeof SnapTrPixelOptions, true, false>
 

--- a/packages/script/src/runtime/registry/vimeo-player.ts
+++ b/packages/script/src/runtime/registry/vimeo-player.ts
@@ -15,7 +15,11 @@ export interface VimeoPlayerApi {
 export type VimeoPlayerInput = RegistryScriptInput
 
 declare global {
-  interface Window extends VimeoPlayerApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    Vimeo: VimeoPlayerApi['Vimeo']
+  }
 }
 
 export function useScriptVimeoPlayer<T extends VimeoPlayerApi>(_options?: VimeoPlayerInput): UseScriptContext<T> {

--- a/packages/script/src/runtime/registry/x-pixel.ts
+++ b/packages/script/src/runtime/registry/x-pixel.ts
@@ -36,7 +36,11 @@ export interface XPixelApi {
 }
 
 declare global {
-  interface Window extends XPixelApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    twq: XPixelApi['twq']
+  }
 }
 
 export { XPixelOptions }

--- a/packages/script/src/runtime/registry/youtube-player.ts
+++ b/packages/script/src/runtime/registry/youtube-player.ts
@@ -28,7 +28,10 @@ export interface YouTubePlayerApi {
 }
 
 declare global {
-  interface Window extends YouTubePlayerApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    YT: YouTubePlayerApi['YT']
     onYouTubeIframeAPIReady?: () => void
   }
 }

--- a/test/types/global-window.test-d.ts
+++ b/test/types/global-window.test-d.ts
@@ -1,4 +1,23 @@
+import type { AhrefsAnalyticsApi } from '../../packages/script/src/runtime/registry/ahrefs-analytics'
+import type { CalendlyApi } from '../../packages/script/src/runtime/registry/calendly'
+import type { ClarityApi } from '../../packages/script/src/runtime/registry/clarity'
+import type { CloudflareWebAnalyticsApi } from '../../packages/script/src/runtime/registry/cloudflare-web-analytics'
+import type { GoogleAdsenseApi } from '../../packages/script/src/runtime/registry/google-adsense'
+import type { GoogleRecaptchaApi } from '../../packages/script/src/runtime/registry/google-recaptcha'
 import type { GoogleTagManagerApi } from '../../packages/script/src/runtime/registry/google-tag-manager'
+import type { HotjarApi } from '../../packages/script/src/runtime/registry/hotjar'
+import type { IntercomApi } from '../../packages/script/src/runtime/registry/intercom'
+import type { LeafletApi } from '../../packages/script/src/runtime/registry/leaflet'
+import type { LinkedInInsightApi } from '../../packages/script/src/runtime/registry/linkedin-insight'
+import type { MatomoAnalyticsApi } from '../../packages/script/src/runtime/registry/matomo-analytics'
+import type { MetaPixelApi } from '../../packages/script/src/runtime/registry/meta-pixel'
+import type { PayPalApi } from '../../packages/script/src/runtime/registry/paypal'
+import type { RedditPixelApi } from '../../packages/script/src/runtime/registry/reddit-pixel'
+import type { SegmentApi } from '../../packages/script/src/runtime/registry/segment'
+import type { SnapPixelApi } from '../../packages/script/src/runtime/registry/snapchat-pixel'
+import type { VimeoPlayerApi } from '../../packages/script/src/runtime/registry/vimeo-player'
+import type { XPixelApi } from '../../packages/script/src/runtime/registry/x-pixel'
+import type { YouTubePlayerApi } from '../../packages/script/src/runtime/registry/youtube-player'
 import { describe, expectTypeOf, it } from 'vitest'
 
 /**
@@ -27,5 +46,142 @@ describe('global `Window` augmentation', () => {
   it('still types `dataLayer` on the GTM proxy API', () => {
     expectTypeOf<GoogleTagManagerApi['dataLayer']>().not.toBeAny()
     expectTypeOf<GoogleTagManagerApi['dataLayer']['push']>().toBeCallableWith({ event: 'test' })
+  })
+})
+
+/**
+ * Follow-up sweep for #852 / #855.
+ *
+ * Registry entries used to reach the global `Window` through `interface Window extends XApi {}`.
+ * That shape is what turns a routine member collision into an unsuppressable failure: when any
+ * other package declares one of the same members, the merged `Window` stops satisfying the
+ * `extends` clause, and TypeScript reports TS2430 at *every* `Window` augmentation in the
+ * program — including the consumer's own, which are nowhere near the cause and which
+ * `skipLibCheck` cannot silence because they are the consumer's own `.ts` files.
+ *
+ * Declaring the members inline removes the `extends` clause, so that failure mode cannot occur:
+ * a genuine collision now surfaces as TS2687/TS2717 on the two conflicting declarations, which
+ * are both in `.d.ts` files and are therefore covered by `skipLibCheck` like any other
+ * dependency-vs-dependency disagreement.
+ *
+ * These assertions pin the member types to their API interfaces, so the rewrite stays
+ * type-identical to the `extends` form it replaced and cannot silently drift.
+ */
+describe('registry `Window` members match their API interfaces', () => {
+  it('ahrefs-analytics', () => {
+    expectTypeOf<Window['AhrefsAnalytics']>().toEqualTypeOf<AhrefsAnalyticsApi['AhrefsAnalytics']>()
+  })
+
+  it('calendly', () => {
+    expectTypeOf<Window['Calendly']>().toEqualTypeOf<CalendlyApi['Calendly']>()
+  })
+
+  it('clarity', () => {
+    expectTypeOf<Window['clarity']>().toEqualTypeOf<ClarityApi['clarity']>()
+  })
+
+  it('cloudflare-web-analytics', () => {
+    expectTypeOf<Window['__cfBeacon']>().toEqualTypeOf<CloudflareWebAnalyticsApi['__cfBeacon']>()
+  })
+
+  it('google-adsense', () => {
+    expectTypeOf<Window['adsbygoogle']>().toEqualTypeOf<GoogleAdsenseApi['adsbygoogle']>()
+  })
+
+  it('google-recaptcha', () => {
+    expectTypeOf<Window['grecaptcha']>().toEqualTypeOf<GoogleRecaptchaApi['grecaptcha']>()
+  })
+
+  it('hotjar', () => {
+    expectTypeOf<Window['hj']>().toEqualTypeOf<HotjarApi['hj']>()
+    expectTypeOf<Window['_hjSettings']>().toEqualTypeOf<{ hjid: number, hjsv?: number }>()
+  })
+
+  it('intercom', () => {
+    expectTypeOf<Window['Intercom']>().toEqualTypeOf<IntercomApi['Intercom']>()
+  })
+
+  it('leaflet', () => {
+    expectTypeOf<Window['L']>().toEqualTypeOf<LeafletApi['L']>()
+  })
+
+  it('linkedin-insight', () => {
+    expectTypeOf<Window['lintrk']>().toEqualTypeOf<LinkedInInsightApi['lintrk']>()
+  })
+
+  it('matomo-analytics', () => {
+    expectTypeOf<Window['_paq']>().toEqualTypeOf<MatomoAnalyticsApi['_paq']>()
+  })
+
+  it('meta-pixel', () => {
+    expectTypeOf<Window['fbq']>().toEqualTypeOf<MetaPixelApi['fbq']>()
+    expectTypeOf<Window['_fbq']>().toEqualTypeOf<MetaPixelApi['_fbq']>()
+    expectTypeOf<Window['callMethod']>().toEqualTypeOf<MetaPixelApi['callMethod']>()
+  })
+
+  it('paypal', () => {
+    expectTypeOf<Window['paypal']>().toEqualTypeOf<PayPalApi['paypal']>()
+  })
+
+  it('reddit-pixel', () => {
+    expectTypeOf<Window['rdt']>().toEqualTypeOf<RedditPixelApi['rdt']>()
+  })
+
+  it('segment', () => {
+    expectTypeOf<Window['track']>().toEqualTypeOf<SegmentApi['track']>()
+    expectTypeOf<Window['page']>().toEqualTypeOf<SegmentApi['page']>()
+    expectTypeOf<Window['identify']>().toEqualTypeOf<SegmentApi['identify']>()
+    expectTypeOf<Window['group']>().toEqualTypeOf<SegmentApi['group']>()
+    expectTypeOf<Window['alias']>().toEqualTypeOf<SegmentApi['alias']>()
+    expectTypeOf<Window['reset']>().toEqualTypeOf<SegmentApi['reset']>()
+  })
+
+  it('snapchat-pixel', () => {
+    expectTypeOf<Window['snaptr']>().toEqualTypeOf<SnapPixelApi['snaptr']>()
+    expectTypeOf<Window['_snaptr']>().toEqualTypeOf<SnapPixelApi['_snaptr']>()
+    expectTypeOf<Window['handleRequest']>().toEqualTypeOf<SnapPixelApi['handleRequest']>()
+  })
+
+  it('vimeo-player', () => {
+    expectTypeOf<Window['Vimeo']>().toEqualTypeOf<VimeoPlayerApi['Vimeo']>()
+  })
+
+  it('x-pixel', () => {
+    expectTypeOf<Window['twq']>().toEqualTypeOf<XPixelApi['twq']>()
+  })
+
+  it('youtube-player', () => {
+    expectTypeOf<Window['YT']>().toEqualTypeOf<YouTubePlayerApi['YT']>()
+    expectTypeOf<Window['onYouTubeIframeAPIReady']>().toEqualTypeOf<(() => void) | undefined>()
+  })
+
+  /**
+   * The inline lists above must not go stale: if an API interface gains a member, the matching
+   * `Window` declaration has to gain it too, or the registry's own `window.<member>` reads stop
+   * typechecking. `extends` used to keep the two in step automatically.
+   *
+   * `GoogleTagManagerApi` is deliberately excluded — `dataLayer` is intentionally *not* global
+   * (#855), which is the one case where the two are meant to diverge.
+   */
+  it('declares every API member on `Window`', () => {
+    expectTypeOf<Exclude<keyof AhrefsAnalyticsApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof CalendlyApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof ClarityApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof CloudflareWebAnalyticsApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof GoogleAdsenseApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof GoogleRecaptchaApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof HotjarApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof IntercomApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof LeafletApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof LinkedInInsightApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof MatomoAnalyticsApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof MetaPixelApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof PayPalApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof RedditPixelApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof SegmentApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof SnapPixelApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof VimeoPlayerApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof XPixelApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof YouTubePlayerApi, keyof Window>>().toEqualTypeOf<never>()
   })
 })

--- a/test/unit/global-window-augmentation.test.ts
+++ b/test/unit/global-window-augmentation.test.ts
@@ -1,0 +1,36 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const REGISTRY_DIR = join(import.meta.dirname, '../../packages/script/src/runtime/registry')
+
+/**
+ * Guard for #852 / #855.
+ *
+ * A registry entry must not reach the global `Window` through an `extends` clause
+ * (`interface Window extends XApi {}`). Interface declarations merge, so as soon as any other
+ * package declares one of the same members — `@gtm-support/core` declaring
+ * `Window.dataLayer?: DataLayerObject[]` is the case that started this — the merged `Window`
+ * stops satisfying that clause. TypeScript then reports TS2430 at *every* `Window` augmentation
+ * in the program, including the consumer's own, which are nowhere near the cause and which
+ * `skipLibCheck` cannot silence because they live in the consumer's own `.ts` files.
+ *
+ * Declaring the members inline (`interface Window { xApi: XApi['xApi'] }`) is type-identical and
+ * removes that failure mode: a real collision then surfaces as TS2687/TS2717 on the two
+ * conflicting declarations, both of which are in `.d.ts` files and so fall under `skipLibCheck`
+ * like any other dependency-vs-dependency disagreement.
+ */
+describe('registry global `Window` augmentations', () => {
+  const entries = readdirSync(REGISTRY_DIR).filter(f => f.endsWith('.ts'))
+
+  it('finds registry sources to check', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  it('never augments the global `Window` via an `extends` clause', () => {
+    const offenders = entries.filter(file =>
+      /\binterface\s+Window\s+extends\b/.test(readFileSync(join(REGISTRY_DIR, file), 'utf8')),
+    )
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
Follow-up sweep for #852, invited by the triage note on #855:

> About 25 other registry entries use the same `interface Window extends XApi {}` shape with required members, so the collision class stays open. A follow-up sweep would close it.

#855 fixed the GTM entry by narrowing *which* members reach the global `Window`. This closes the class by changing the *shape* that makes a collision catastrophic in the first place.

### The defect class

`interface Window extends XApi {}` is the part that turns a routine member collision into an unsuppressable failure. Interface declarations merge, so when any other package declares one of the same members, the merged `Window` stops satisfying the `extends` clause this package added — and TypeScript reports `TS2430` at **every** `Window` augmentation in the program, including the consumer's own. Those are nowhere near the cause, and `skipLibCheck` cannot silence them because they are the consumer's own `.ts` files.

Declaring the same members inline removes the clause that can fail:

```diff
-  interface Window extends PayPalApi {}
+  interface Window {
+    paypal: PayPalApi['paypal']
+  }
```

A genuine collision then surfaces as `TS2687`/`TS2717` **on the two conflicting declarations**, which are both in `.d.ts` files and therefore fall under `skipLibCheck` like any other dependency-vs-dependency disagreement — diagnosable, and pointing at the actual cause.

### This is not hypothetical — there is a second live instance

`@paypal/paypal-js` (the official PayPal SDK types, and a direct devDependency of this repo) declares:

```ts
// @paypal/paypal-js@10.1.0 types/index.d.ts
declare global {
  interface Window { paypal?: PayPalNamespace | null }
}
```

The registry declared `paypal: PayPalV6Namespace` — required, and a different namespace type. Same two stacked incompatibilities as `@gtm-support/core`. Verified against the real package, `strict`, `skipLibCheck: true`, with a consumer that augments `Window` from a `.ts` file:

| | tsgo 7.0.0-dev | tsc 6.0.3 |
| --- | --- | --- |
| before | ❌ `TS2430` at `consumer.ts` | ✅ clean |
| after | ✅ clean | ✅ clean |

### Correction to the framing in #855

The triage note on #855 said:

> `tsc` is not silent, contrary to the PR table. TS 5.9 reports the same `TS2430` once the consumer augments `Window` from a `.ts` file. Only a `.d.ts`-only conflict is hidden by `skipLibCheck`.

I could not reproduce that, and measured the opposite. On **TS 5.9.3 and 6.0.3** the `TS2430` anchors to `lib.dom.d.ts` — the primary `Window` declaration — so `skipLibCheck: true` suppresses it **regardless** of whether the consumer augments `Window` from a `.ts` file, a `.d.ts` file, or with its own `extends` clause. It surfaces pre-TS7 only with `skipLibCheck: false`. On **tsgo** the error is instead attributed to every augmentation site, including the consumer's own `.ts` files, which is why `skipLibCheck` stops helping. That matches the original report in #852.

The conclusion still holds, but for a different reason, and it is worth stating precisely because it bounds what this PR fixes:

- **Pre-TS7**, the foreign *optional* declaration silently wins the merge, so consumers reading `window.paypal` get `TS2722`/`TS18048` "possibly undefined" at each read site. **This PR does not change that** — it is inherent to declaration merging, and it is equally true before and after.
- **On TS7**, the collision additionally becomes an unsuppressable `TS2430` at every consumer `Window` augmentation. **That is what this PR eliminates.**

Happy to be shown the configuration behind the original note if I've missed one — the repro is four files and I can push it as a fixture.

### Scope

20 entries, all in `packages/script/src/runtime/registry/`: `ahrefs-analytics`, `calendly`, `clarity`, `cloudflare-web-analytics`, `google-adsense`, `google-recaptcha`, `hotjar`, `intercom`, `leaflet`, `linkedin-insight`, `matomo-analytics`, `meta-pixel`, `paypal`, `reddit-pixel`, `segment`, `snapchat-pixel`, `vimeo-player`, `x-pixel`, `youtube-player` — plus `google-tag-manager`, because #855's `Pick<GoogleTagManagerApi, 'google_tag_manager'>` narrowed the surface but kept the `extends` clause, so that entry still carried the shape for its remaining member.

The exact figure is 19 unfixed entries rather than ~25. The other `Window` augmentations in the registry (`bing-uet`, `crisp`, `databuddy-analytics`, `deskcrew`, `fathom-analytics`, `lemon-squeezy`, `maplibre`, `mixpanel-analytics`, `plausible-analytics`, `posthog`, `rybbit-analytics`, `speedcurve`, `tiktok-pixel`, `umami-analytics`, `usercentrics`, `vercel-analytics`) already declare members inline, so they cannot produce `TS2430` and are left untouched.

### Semver — your call

**As written, this is not a type break.** Every member keeps its exact type and its exact required/optional modifier; `Window['fbq']` and friends resolve to what they resolved to before. That is the reason I did not port #855's `Pick<>` literally: dropping members across 19 entries *would* be the broad break the triage note anticipated, and unlike GTM's `dataLayer` — reached through `(window as any)[dataLayerName]` because its name is configurable — most of these members are read off bare `window` by the registries themselves, so removing them would also break this package's own build.

There is a stronger version available if you want it: for entries whose member is genuinely not guaranteed to exist under that name, drop it from the global `Window` GTM-style and let the `useScript*()` proxy be the only typed access path. That *is* a break for anyone reading `window.<prop>` directly, and it is much broader than it was for GTM alone. I have deliberately not made that call — say the word and I will do it as a follow-up, behind whatever version you want.

Worth noting either way: `segment` puts six very generic names on the global `Window` — `track`, `page`, `identify`, `group`, `alias`, `reset`. Those are the most likely of the whole registry to collide with something. This PR does not change that, but it does mean a collision on them no longer takes the consumer's build down at a distance.

### Tests

Extends `test/types/global-window.test-d.ts` (the file the bot pushed onto #855) rather than adding a harness:

- every swept member is pinned to its API interface with `toEqualTypeOf`, so the rewrite stays type-identical to the `extends` form it replaced — this is the guard on the "not a type break" claim above;
- a drift guard asserts `Exclude<keyof XApi, keyof Window>` is `never` for each entry, since inline lists no longer track the API automatically the way `extends` did. `GoogleTagManagerApi` is exempted, as `dataLayer` is deliberately not global per #855. Verified to fail when a member is removed from a `Window` declaration.

Type-level assertions cannot fail on the pre-fix code here — that is precisely what "type-identical" means — so the invariant itself is guarded by `test/unit/global-window-augmentation.test.ts`, which scans the registry sources and asserts none declares `Window` via an `extends` clause. It fails on `main` listing all 20 offenders, and passes on this branch.

### Verification

`pnpm lint`, `pnpm typecheck`, and `pnpm vitest run --project typecheck --project unit` (78 files, 941 tests) all pass. Not run locally: `e2e` (needs browsers) and `build`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
