### PR TITLE
docs(tutorial): declare `Window` members inline, not via `extends`

### DIFF
--- a/docs/content/docs/1.getting-started/3.confetti-tutorial.md
+++ b/docs/content/docs/1.getting-started/3.confetti-tutorial.md
@@ -139,7 +139,9 @@ export interface JSConfettiApi {
 }
 
 declare global {
-  interface Window extends JSConfettiApi {}
+  interface Window {
+    JSConfetti: JSConfettiApi['JSConfetti']
+  }
 }
 
 const { onLoaded } = useScriptNpm<JSConfettiApi>({


### PR DESCRIPTION
Follow-up to #878.

The confetti tutorial still taught `declare global { interface Window extends JSConfettiApi {} }` — the exact shape #878 removes from the registry. An `extends` clause on the global `Window` turns any member collision with another package into an unsuppressable TS2430 at every consumer `Window` augmentation (#852). Declaring the member inline is type-identical and removes that failure mode.

Discovered during adversarial review of #878; one-line snippet change, verified by `pnpm lint`.