### PR TITLE
fix(registry): don't declare the global `Window` via `extends` (1.x backport)

### DIFF
--- a/packages/script/src/runtime/registry/ahrefs-analytics.ts
+++ b/packages/script/src/runtime/registry/ahrefs-analytics.ts
@@ -29,7 +29,11 @@ export interface AhrefsAnalyticsApi {
 }
 
 declare global {
-  interface Window extends AhrefsAnalyticsApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    AhrefsAnalytics: AhrefsAnalyticsApi['AhrefsAnalytics']
+  }
 }
 
 /**

--- a/packages/script/src/runtime/registry/calendly.ts
+++ b/packages/script/src/runtime/registry/calendly.ts
@@ -76,7 +76,11 @@ export interface CalendlyApi {
 }
 
 declare global {
-  interface Window extends CalendlyApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    Calendly: CalendlyApi['Calendly']
+  }
 }
 
 const CALENDLY_CSS_KEY = 'nuxt-scripts-calendly-css'

--- a/packages/script/src/runtime/registry/clarity.ts
+++ b/packages/script/src/runtime/registry/clarity.ts
@@ -25,7 +25,11 @@ export interface ClarityApi {
 }
 
 declare global {
-  interface Window extends ClarityApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    clarity: ClarityApi['clarity']
+  }
 }
 
 export type ClarityInput = RegistryScriptInput<typeof ClarityOptions>

--- a/packages/script/src/runtime/registry/cloudflare-web-analytics.ts
+++ b/packages/script/src/runtime/registry/cloudflare-web-analytics.ts
@@ -20,7 +20,11 @@ export interface CloudflareWebAnalyticsApi {
 }
 
 declare global {
-  interface Window extends CloudflareWebAnalyticsApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    __cfBeacon: CloudflareWebAnalyticsApi['__cfBeacon']
+  }
 }
 
 export type CloudflareWebAnalyticsInput = RegistryScriptInput<typeof CloudflareWebAnalyticsOptions>

--- a/packages/script/src/runtime/registry/google-adsense.ts
+++ b/packages/script/src/runtime/registry/google-adsense.ts
@@ -15,7 +15,11 @@ export interface GoogleAdsenseApi {
 }
 
 declare global {
-  interface Window extends GoogleAdsenseApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    adsbygoogle: GoogleAdsenseApi['adsbygoogle']
+  }
 }
 
 /**

--- a/packages/script/src/runtime/registry/google-recaptcha.ts
+++ b/packages/script/src/runtime/registry/google-recaptcha.ts
@@ -19,7 +19,11 @@ export interface GoogleRecaptchaApi {
 }
 
 declare global {
-  interface Window extends GoogleRecaptchaApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    grecaptcha: GoogleRecaptchaApi['grecaptcha']
+  }
 }
 
 export function useScriptGoogleRecaptcha<T extends GoogleRecaptchaApi>(_options?: GoogleRecaptchaInput) {

--- a/packages/script/src/runtime/registry/google-tag-manager.ts
+++ b/packages/script/src/runtime/registry/google-tag-manager.ts
@@ -82,7 +82,11 @@ export interface GoogleTagManagerApi {
  * instead, which is also the only access path that respects a custom dataLayer name.
  */
 declare global {
-  interface Window extends Pick<GoogleTagManagerApi, 'google_tag_manager'> {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    google_tag_manager: GoogleTagManagerApi['google_tag_manager']
+  }
 }
 
 export { GoogleTagManagerOptions }

--- a/packages/script/src/runtime/registry/hotjar.ts
+++ b/packages/script/src/runtime/registry/hotjar.ts
@@ -11,7 +11,10 @@ export interface HotjarApi {
 }
 
 declare global {
-  interface Window extends HotjarApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    hj: HotjarApi['hj']
     _hjSettings: { hjid: number, hjsv?: number }
   }
 }

--- a/packages/script/src/runtime/registry/intercom.ts
+++ b/packages/script/src/runtime/registry/intercom.ts
@@ -34,7 +34,10 @@ export interface IntercomApi {
 }
 
 declare global {
-  interface Window extends IntercomApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    Intercom: IntercomApi['Intercom']
     intercomSettings?: any
   }
 }

--- a/packages/script/src/runtime/registry/linkedin-insight.ts
+++ b/packages/script/src/runtime/registry/linkedin-insight.ts
@@ -29,7 +29,10 @@ export interface LinkedInInsightApi {
 }
 
 declare global {
-  interface Window extends LinkedInInsightApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    lintrk: LinkedInInsightApi['lintrk']
     _linkedin_partner_id?: string
     _linkedin_data_partner_ids?: string[]
     _linkedin_event_id?: string

--- a/packages/script/src/runtime/registry/matomo-analytics.ts
+++ b/packages/script/src/runtime/registry/matomo-analytics.ts
@@ -14,7 +14,11 @@ export interface MatomoAnalyticsApi {
 }
 
 declare global {
-  interface Window extends MatomoAnalyticsApi { }
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    _paq: MatomoAnalyticsApi['_paq']
+  }
 }
 
 export interface MatomoConsent {

--- a/packages/script/src/runtime/registry/meta-pixel.ts
+++ b/packages/script/src/runtime/registry/meta-pixel.ts
@@ -44,7 +44,13 @@ export interface MetaPixelApi {
 }
 
 declare global {
-  interface Window extends MetaPixelApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    fbq: MetaPixelApi['fbq']
+    _fbq: MetaPixelApi['_fbq']
+    callMethod?: MetaPixelApi['callMethod']
+  }
 }
 
 export { MetaPixelOptions }

--- a/packages/script/src/runtime/registry/paypal.ts
+++ b/packages/script/src/runtime/registry/paypal.ts
@@ -10,7 +10,10 @@ export interface PayPalApi {
 }
 
 declare global {
-  interface Window extends PayPalApi {
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    paypal: PayPalApi['paypal']
   }
 }
 

--- a/packages/script/src/runtime/registry/reddit-pixel.ts
+++ b/packages/script/src/runtime/registry/reddit-pixel.ts
@@ -17,7 +17,11 @@ export interface RedditPixelApi {
 }
 
 declare global {
-  interface Window extends RedditPixelApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    rdt: RedditPixelApi['rdt']
+  }
 }
 
 export { RedditPixelOptions }

--- a/packages/script/src/runtime/registry/segment.ts
+++ b/packages/script/src/runtime/registry/segment.ts
@@ -31,7 +31,16 @@ interface AnalyticsApi {
 export type SegmentApi = Pick<AnalyticsApi, 'track' | 'page' | 'identify' | 'group' | 'alias' | 'reset'>
 
 declare global {
-  interface Window extends SegmentApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    track: SegmentApi['track']
+    page: SegmentApi['page']
+    identify: SegmentApi['identify']
+    group: SegmentApi['group']
+    alias: SegmentApi['alias']
+    reset: SegmentApi['reset']
+  }
 }
 
 const methods = ['track', 'page', 'identify', 'group', 'alias', 'reset']

--- a/packages/script/src/runtime/registry/snapchat-pixel.ts
+++ b/packages/script/src/runtime/registry/snapchat-pixel.ts
@@ -47,7 +47,13 @@ export interface SnapPixelApi {
 }
 
 declare global {
-  interface Window extends SnapPixelApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    snaptr: SnapPixelApi['snaptr']
+    _snaptr: SnapPixelApi['_snaptr']
+    handleRequest?: SnapPixelApi['handleRequest']
+  }
 }
 export type SnapTrPixelInput = RegistryScriptInput<typeof SnapTrPixelOptions, true, false>
 

--- a/packages/script/src/runtime/registry/vimeo-player.ts
+++ b/packages/script/src/runtime/registry/vimeo-player.ts
@@ -15,7 +15,11 @@ export interface VimeoPlayerApi {
 export type VimeoPlayerInput = RegistryScriptInput
 
 declare global {
-  interface Window extends VimeoPlayerApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    Vimeo: VimeoPlayerApi['Vimeo']
+  }
 }
 
 export function useScriptVimeoPlayer<T extends VimeoPlayerApi>(_options?: VimeoPlayerInput): UseScriptContext<T> {

--- a/packages/script/src/runtime/registry/x-pixel.ts
+++ b/packages/script/src/runtime/registry/x-pixel.ts
@@ -36,7 +36,11 @@ export interface XPixelApi {
 }
 
 declare global {
-  interface Window extends XPixelApi {}
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    twq: XPixelApi['twq']
+  }
 }
 
 export { XPixelOptions }

--- a/packages/script/src/runtime/registry/youtube-player.ts
+++ b/packages/script/src/runtime/registry/youtube-player.ts
@@ -30,8 +30,11 @@ export interface YouTubePlayerApi {
 }
 
 declare global {
-  interface Window extends YouTubePlayerApi {
-    onYouTubeIframeAPIReady: () => void
+  // Declared inline rather than via `extends`: an `extends` clause on the global `Window`
+  // surfaces as an unsuppressable TS2430 in consumer code when another package declares it (#852).
+  interface Window {
+    YT: YouTubePlayerApi['YT']
+    onYouTubeIframeAPIReady?: () => void
   }
 }
 

--- a/test/types/global-window.test-d.ts
+++ b/test/types/global-window.test-d.ts
@@ -1,4 +1,22 @@
+import type { AhrefsAnalyticsApi } from '../../packages/script/src/runtime/registry/ahrefs-analytics'
+import type { CalendlyApi } from '../../packages/script/src/runtime/registry/calendly'
+import type { ClarityApi } from '../../packages/script/src/runtime/registry/clarity'
+import type { CloudflareWebAnalyticsApi } from '../../packages/script/src/runtime/registry/cloudflare-web-analytics'
+import type { GoogleAdsenseApi } from '../../packages/script/src/runtime/registry/google-adsense'
+import type { GoogleRecaptchaApi } from '../../packages/script/src/runtime/registry/google-recaptcha'
 import type { GoogleTagManagerApi } from '../../packages/script/src/runtime/registry/google-tag-manager'
+import type { HotjarApi } from '../../packages/script/src/runtime/registry/hotjar'
+import type { IntercomApi } from '../../packages/script/src/runtime/registry/intercom'
+import type { LinkedInInsightApi } from '../../packages/script/src/runtime/registry/linkedin-insight'
+import type { MatomoAnalyticsApi } from '../../packages/script/src/runtime/registry/matomo-analytics'
+import type { MetaPixelApi } from '../../packages/script/src/runtime/registry/meta-pixel'
+import type { PayPalApi } from '../../packages/script/src/runtime/registry/paypal'
+import type { RedditPixelApi } from '../../packages/script/src/runtime/registry/reddit-pixel'
+import type { SegmentApi } from '../../packages/script/src/runtime/registry/segment'
+import type { SnapPixelApi } from '../../packages/script/src/runtime/registry/snapchat-pixel'
+import type { VimeoPlayerApi } from '../../packages/script/src/runtime/registry/vimeo-player'
+import type { XPixelApi } from '../../packages/script/src/runtime/registry/x-pixel'
+import type { YouTubePlayerApi } from '../../packages/script/src/runtime/registry/youtube-player'
 import { describe, expectTypeOf, it } from 'vitest'
 
 /**
@@ -27,5 +45,137 @@ describe('global `Window` augmentation', () => {
   it('still types `dataLayer` on the GTM proxy API', () => {
     expectTypeOf<GoogleTagManagerApi['dataLayer']>().not.toBeAny()
     expectTypeOf<GoogleTagManagerApi['dataLayer']['push']>().toBeCallableWith({ event: 'test' })
+  })
+})
+
+/**
+ * Follow-up sweep for #852 / #855.
+ *
+ * Registry entries used to reach the global `Window` through `interface Window extends XApi {}`.
+ * That shape is what turns a routine member collision into an unsuppressable failure: when any
+ * other package declares one of the same members, the merged `Window` stops satisfying the
+ * `extends` clause, and TypeScript reports TS2430 at *every* `Window` augmentation in the
+ * program — including the consumer's own, which are nowhere near the cause and which
+ * `skipLibCheck` cannot silence because they are the consumer's own `.ts` files.
+ *
+ * Declaring the members inline removes the `extends` clause, so that failure mode cannot occur:
+ * a genuine collision now surfaces as TS2687/TS2717 on the two conflicting declarations, which
+ * are both in `.d.ts` files and are therefore covered by `skipLibCheck` like any other
+ * dependency-vs-dependency disagreement.
+ *
+ * These assertions pin the member types to their API interfaces, so the rewrite stays
+ * type-identical to the `extends` form it replaced and cannot silently drift.
+ */
+describe('registry `Window` members match their API interfaces', () => {
+  it('ahrefs-analytics', () => {
+    expectTypeOf<Window['AhrefsAnalytics']>().toEqualTypeOf<AhrefsAnalyticsApi['AhrefsAnalytics']>()
+  })
+
+  it('calendly', () => {
+    expectTypeOf<Window['Calendly']>().toEqualTypeOf<CalendlyApi['Calendly']>()
+  })
+
+  it('clarity', () => {
+    expectTypeOf<Window['clarity']>().toEqualTypeOf<ClarityApi['clarity']>()
+  })
+
+  it('cloudflare-web-analytics', () => {
+    expectTypeOf<Window['__cfBeacon']>().toEqualTypeOf<CloudflareWebAnalyticsApi['__cfBeacon']>()
+  })
+
+  it('google-adsense', () => {
+    expectTypeOf<Window['adsbygoogle']>().toEqualTypeOf<GoogleAdsenseApi['adsbygoogle']>()
+  })
+
+  it('google-recaptcha', () => {
+    expectTypeOf<Window['grecaptcha']>().toEqualTypeOf<GoogleRecaptchaApi['grecaptcha']>()
+  })
+
+  it('hotjar', () => {
+    expectTypeOf<Window['hj']>().toEqualTypeOf<HotjarApi['hj']>()
+    expectTypeOf<Window['_hjSettings']>().toEqualTypeOf<{ hjid: number, hjsv?: number }>()
+  })
+
+  it('intercom', () => {
+    expectTypeOf<Window['Intercom']>().toEqualTypeOf<IntercomApi['Intercom']>()
+  })
+
+  it('linkedin-insight', () => {
+    expectTypeOf<Window['lintrk']>().toEqualTypeOf<LinkedInInsightApi['lintrk']>()
+  })
+
+  it('matomo-analytics', () => {
+    expectTypeOf<Window['_paq']>().toEqualTypeOf<MatomoAnalyticsApi['_paq']>()
+  })
+
+  it('meta-pixel', () => {
+    expectTypeOf<Window['fbq']>().toEqualTypeOf<MetaPixelApi['fbq']>()
+    expectTypeOf<Window['_fbq']>().toEqualTypeOf<MetaPixelApi['_fbq']>()
+    expectTypeOf<Window['callMethod']>().toEqualTypeOf<MetaPixelApi['callMethod']>()
+  })
+
+  it('paypal', () => {
+    expectTypeOf<Window['paypal']>().toEqualTypeOf<PayPalApi['paypal']>()
+  })
+
+  it('reddit-pixel', () => {
+    expectTypeOf<Window['rdt']>().toEqualTypeOf<RedditPixelApi['rdt']>()
+  })
+
+  it('segment', () => {
+    expectTypeOf<Window['track']>().toEqualTypeOf<SegmentApi['track']>()
+    expectTypeOf<Window['page']>().toEqualTypeOf<SegmentApi['page']>()
+    expectTypeOf<Window['identify']>().toEqualTypeOf<SegmentApi['identify']>()
+    expectTypeOf<Window['group']>().toEqualTypeOf<SegmentApi['group']>()
+    expectTypeOf<Window['alias']>().toEqualTypeOf<SegmentApi['alias']>()
+    expectTypeOf<Window['reset']>().toEqualTypeOf<SegmentApi['reset']>()
+  })
+
+  it('snapchat-pixel', () => {
+    expectTypeOf<Window['snaptr']>().toEqualTypeOf<SnapPixelApi['snaptr']>()
+    expectTypeOf<Window['_snaptr']>().toEqualTypeOf<SnapPixelApi['_snaptr']>()
+    expectTypeOf<Window['handleRequest']>().toEqualTypeOf<SnapPixelApi['handleRequest']>()
+  })
+
+  it('vimeo-player', () => {
+    expectTypeOf<Window['Vimeo']>().toEqualTypeOf<VimeoPlayerApi['Vimeo']>()
+  })
+
+  it('x-pixel', () => {
+    expectTypeOf<Window['twq']>().toEqualTypeOf<XPixelApi['twq']>()
+  })
+
+  it('youtube-player', () => {
+    expectTypeOf<Window['YT']>().toEqualTypeOf<YouTubePlayerApi['YT']>()
+    expectTypeOf<Window['onYouTubeIframeAPIReady']>().toEqualTypeOf<(() => void) | undefined>()
+  })
+
+  /**
+   * The inline lists above must not go stale: if an API interface gains a member, the matching
+   * `Window` declaration has to gain it too, or the registry's own `window.<member>` reads stop
+   * typechecking. `extends` used to keep the two in step automatically.
+   *
+   * `GoogleTagManagerApi` is deliberately excluded — `dataLayer` is intentionally *not* global
+   * (#855), which is the one case where the two are meant to diverge.
+   */
+  it('declares every API member on `Window`', () => {
+    expectTypeOf<Exclude<keyof AhrefsAnalyticsApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof CalendlyApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof ClarityApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof CloudflareWebAnalyticsApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof GoogleAdsenseApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof GoogleRecaptchaApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof HotjarApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof IntercomApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof LinkedInInsightApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof MatomoAnalyticsApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof MetaPixelApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof PayPalApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof RedditPixelApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof SegmentApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof SnapPixelApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof VimeoPlayerApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof XPixelApi, keyof Window>>().toEqualTypeOf<never>()
+    expectTypeOf<Exclude<keyof YouTubePlayerApi, keyof Window>>().toEqualTypeOf<never>()
   })
 })

--- a/test/unit/global-window-augmentation.test.ts
+++ b/test/unit/global-window-augmentation.test.ts
@@ -1,0 +1,36 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const REGISTRY_DIR = join(import.meta.dirname, '../../packages/script/src/runtime/registry')
+
+/**
+ * Guard for #852 / #855.
+ *
+ * A registry entry must not reach the global `Window` through an `extends` clause
+ * (`interface Window extends XApi {}`). Interface declarations merge, so as soon as any other
+ * package declares one of the same members — `@gtm-support/core` declaring
+ * `Window.dataLayer?: DataLayerObject[]` is the case that started this — the merged `Window`
+ * stops satisfying that clause. TypeScript then reports TS2430 at *every* `Window` augmentation
+ * in the program, including the consumer's own, which are nowhere near the cause and which
+ * `skipLibCheck` cannot silence because they live in the consumer's own `.ts` files.
+ *
+ * Declaring the members inline (`interface Window { xApi: XApi['xApi'] }`) is type-identical and
+ * removes that failure mode: a real collision then surfaces as TS2687/TS2717 on the two
+ * conflicting declarations, both of which are in `.d.ts` files and so fall under `skipLibCheck`
+ * like any other dependency-vs-dependency disagreement.
+ */
+describe('registry global `Window` augmentations', () => {
+  const entries = readdirSync(REGISTRY_DIR).filter(f => f.endsWith('.ts'))
+
+  it('finds registry sources to check', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  it('never augments the global `Window` via an `extends` clause', () => {
+    const offenders = entries.filter(file =>
+      /\binterface\s+Window\s+extends\b/.test(readFileSync(join(REGISTRY_DIR, file), 'utf8')),
+    )
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
Backport of #878 to `1.x`.

## Changes

- Replaces every `interface Window extends XApi {}` in the registry with inline member declarations, so a member collision with another package (e.g. `@gtm-support/core` declaring `dataLayer`) no longer produces unsuppressable TS2430 errors in consumer code (#852).
- Adds a type test pinning each `Window` member to its API interface, and a unit test that fails if any registry entry reintroduces an `extends` clause on `Window`.

## 1.x adaptations

- `leaflet.ts` does not exist on `1.x`, so its registry change and test assertions were dropped.
- `youtube-player.ts` conflict resolved in favor of upstream's optional `onYouTubeIframeAPIReady?: () => void`, which also matches `@types/youtube` and fixes an existing "identical modifiers" type error present on `1.x`.

Verification: unit + type tests for this change pass (`44 passed`, no type errors); the 5 remaining typecheck errors are pre-existing on `1.x` (missing optional deps, unrelated `crisp.ts` issue). Lint passes.