### PR TITLE
fix: accept any warn-capable logger in env validation

### DIFF
--- a/packages/script/src/validate-env.ts
+++ b/packages/script/src/validate-env.ts
@@ -1,5 +1,8 @@
-import type { ConsolaInstance } from 'consola'
 import type { RegistryScript } from './runtime/types'
+
+interface WarnLogger {
+  warn: (message: string) => void
+}
 
 const UPPER_RE = /([A-Z])/g
 const toScreamingSnake = (s: string) => s.replace(UPPER_RE, '_$1').toUpperCase()
@@ -39,7 +42,7 @@ function levenshtein(a: string, b: string): number {
 export function validateScriptsEnvVars(
   scripts: RegistryScript[],
   enabledRegistryKeys: Set<string>,
-  logger: ConsolaInstance,
+  logger: WarnLogger,
   globalsKeys: string[] = [],
 ): void {
   // Configured `scripts.globals` keys — env vars NUXT_PUBLIC_SCRIPTS_GLOBALS_<KEY>_*

--- a/test/unit/validate-env.test.ts
+++ b/test/unit/validate-env.test.ts
@@ -1,4 +1,3 @@
-import type { ConsolaInstance } from 'consola'
 import type { RegistryScript } from '../../packages/script/src/runtime/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { validateScriptsEnvVars } from '../../packages/script/src/validate-env'
@@ -10,7 +9,7 @@ const scripts = [
 ] as unknown as RegistryScript[]
 
 function makeLogger() {
-  return { warn: vi.fn() } as unknown as ConsolaInstance
+  return { warn: vi.fn() }
 }
 
 describe('validateScriptsEnvVars', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I have a better fix coming in (self-contained nuxt/kit types for the logger) but for now this should unbreak ecosystem-ci