### PR TITLE
fix(proxy): follow allowlisted upstream redirects

### DIFF
--- a/packages/script/src/runtime/server/proxy-handler.ts
+++ b/packages/script/src/runtime/server/proxy-handler.ts
@@ -30,6 +30,7 @@ const COMPRESSION_RE = /gzip|deflate|br|compress|base64/i
 const CLIENT_HINT_VERSION_RE = /;v="(\d+)\.[^"]*"/g
 const MAX_TRANSFORM_BODY_SIZE = 2 * 1024 * 1024
 const UPSTREAM_TIMEOUT_MS = 15000
+const MAX_UPSTREAM_REDIRECTS = 5
 const SKIP_RESPONSE_HEADERS = new Set([
   'alt-svc',
   'clear-site-data',
@@ -63,7 +64,11 @@ export const SKIP_REQUEST_HEADERS = new Set([
   'upgrade',
 ])
 
-async function readTransformBody(event: Parameters<typeof getRequestWebStream>[0]): Promise<string | undefined> {
+/**
+ * Read the raw request body bytes, bounded by MAX_TRANSFORM_BODY_SIZE.
+ * Buffering lets privacy transforms and redirect hops replay the same bytes.
+ */
+async function readBodyBytes(event: Parameters<typeof getRequestWebStream>[0]): Promise<Uint8Array<ArrayBuffer> | undefined> {
   const contentLength = Number(getHeaders(event)['content-length'] || 0)
   if (Number.isFinite(contentLength) && contentLength > MAX_TRANSFORM_BODY_SIZE) {
     throw createError({ statusCode: 413, statusMessage: 'Proxy request body too large' })
@@ -105,7 +110,7 @@ async function readTransformBody(event: Parameters<typeof getRequestWebStream>[0
     body.set(chunk, offset)
     offset += chunk.byteLength
   }
-  return new TextDecoder().decode(body)
+  return body
 }
 
 export function withResponseBodyIdleTimeout(
@@ -188,6 +193,92 @@ function stripQueryFingerprinting(
  * Privacy-aware proxy handler for first-party script collection endpoints.
  * Routes requests to third-party analytics while protecting user privacy.
  */
+
+function isUpstreamRedirect(status: number): boolean {
+  return status >= 300 && status < 400 && status !== 304
+}
+
+/** Map a transport failure to the gateway error the client should see. */
+function upstreamFetchError(err: unknown, timedOut: boolean) {
+  const blockedPrivateNetwork = isPrivateNetworkResolutionError(err)
+  return createError({
+    statusCode: blockedPrivateNetwork ? 403 : timedOut ? 504 : 502,
+    statusMessage: blockedPrivateNetwork ? 'Local network targets are not allowed' : timedOut ? 'Gateway Timeout' : 'Bad Gateway',
+    message: 'Proxy upstream request failed',
+    cause: err,
+    data: {
+      errorName: (err as Error)?.name,
+      errorCode: timedOut ? 'TIMEOUT' : (err as { code?: string })?.code,
+    },
+  })
+}
+
+interface ProxyRedirectState {
+  url: URL
+  method: string
+  body: BodyInit | undefined
+  headers: Record<string, string>
+}
+
+/**
+ * Resolve an upstream redirect into the next request state, mirroring the
+ * fetch spec: 300/301/302 replay a POST as a GET without a body, 303 replays
+ * every non-idempotent method as a GET, 307/308 preserve method and body.
+ * The hop is only returned after it passes the initial target's checks.
+ */
+function resolveProxyRedirect(
+  response: Pick<Response, 'status' | 'headers'>,
+  state: ProxyRedirectState,
+  redirectCount: number,
+  urlAllowed: (url: URL) => boolean,
+): ProxyRedirectState {
+  const location = response.headers.get('location')
+  if (!location) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Invalid upstream redirect',
+      message: 'Upstream redirect has no Location header',
+    })
+  }
+  if (redirectCount >= MAX_UPSTREAM_REDIRECTS) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Too many upstream redirects',
+      message: 'Upstream redirect limit exceeded',
+    })
+  }
+
+  let nextUrl: URL
+  try {
+    nextUrl = new URL(location, state.url)
+  }
+  catch (cause) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Invalid upstream redirect',
+      message: 'Upstream redirect URL is invalid',
+      cause,
+    })
+  }
+  if (!urlAllowed(nextUrl)) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Unsafe upstream redirect',
+      message: `Upstream redirect target is not allowed: ${nextUrl.origin}`,
+    })
+  }
+
+  const switchToGet = (response.status === 303 && state.method !== 'GET' && state.method !== 'HEAD')
+    || ((response.status === 300 || response.status === 301 || response.status === 302) && state.method === 'POST')
+  if (!switchToGet)
+    return { ...state, url: nextUrl }
+
+  const headers = { ...state.headers }
+  for (const header of ['content-type', 'content-encoding', 'content-length'])
+    delete headers[header]
+  return { url: nextUrl, method: 'GET', body: undefined, headers }
+}
+
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const proxyConfig = config['nuxt-scripts-proxy'] as unknown as ProxyConfig | undefined
@@ -407,19 +498,22 @@ export default defineEventHandler(async (event) => {
       .join(', ')
   }
 
-  // Process request body: either stream through raw or read + transform
+  // Process request body: buffer the raw bytes once so privacy transforms can
+  // decode them and redirect hops can replay the exact body upstream.
   let body: string | Record<string, unknown> | unknown[] | number | boolean | null | undefined
   let rawBody: unknown
-  // When true, body is not read — the raw request stream is piped directly to upstream
+  let rawBodyBytes: Uint8Array<ArrayBuffer> | undefined
+  // When true, no safe transforms are available — the buffered bytes are forwarded as-is
   let passthroughBody = false
 
   if (isWriteMethod) {
+    rawBodyBytes = await readBodyBytes(event)
     if (!shouldTransformBody) {
-      // No safe transforms available or needed. Stream the original bytes directly.
+      // No safe transforms available or needed. Forward the original bytes.
       passthroughBody = true
     }
     else if (transformableBodyType === 'form') {
-      const formBody = await readTransformBody(event)
+      const formBody = rawBodyBytes === undefined ? undefined : new TextDecoder().decode(rawBodyBytes)
       rawBody = formBody
 
       if (formBody != null) {
@@ -454,7 +548,7 @@ export default defineEventHandler(async (event) => {
     }
     else {
       // JSON body with privacy transforms.
-      const jsonBody = await readTransformBody(event)
+      const jsonBody = rawBodyBytes === undefined ? undefined : new TextDecoder().decode(rawBodyBytes)
       if (jsonBody !== undefined) {
         try {
           rawBody = JSON.parse(jsonBody)
@@ -518,60 +612,83 @@ export default defineEventHandler(async (event) => {
     controller.abort()
   }, UPSTREAM_TIMEOUT_MS)
 
-  // Resolve the fetch body: passthrough streams the raw request, otherwise serialize
+  // Resolve the fetch body from the buffered request bytes so redirect hops
+  // can replay it.
   let fetchBody: BodyInit | undefined
-  if (passthroughBody && originalHeaders['content-length'] !== '0') {
-    fetchBody = getRequestWebStream(event) as BodyInit | undefined
+  if (passthroughBody) {
+    if (rawBodyBytes && rawBodyBytes.byteLength > 0)
+      fetchBody = rawBodyBytes
   }
   else if (body !== undefined) {
     fetchBody = transformableBodyType === 'json' ? JSON.stringify(body) : String(body)
   }
 
+  // A redirect hop must pass the same checks as the initial target: HTTPS on
+  // the default port, no embedded credentials, a public hostname, and the
+  // domain allowlist.
+  const hopAllowed = (url: URL): boolean =>
+    url.protocol === 'https:'
+    && !url.username
+    && !url.password
+    && (!url.port || url.port === '443')
+    && isPublicNetworkHostname(url.hostname)
+    && Object.keys(domainPrivacy).some(configDomain => matchDomain(url.hostname, configDomain))
+
   let response: Response
   let network: Awaited<ReturnType<typeof createPublicNetworkDispatcher>> | undefined
   try {
     network = await createPublicNetworkDispatcher()
-    const requestInit: RequestInit & { duplex?: 'half' } = {
+    let state: ProxyRedirectState = {
+      url: new URL(targetUrl),
       method: method || 'GET',
-      headers,
       body: fetchBody,
-      credentials: 'omit', // Don't send cookies to third parties
-      signal: controller.signal,
-      redirect: 'manual',
-      duplex: fetchBody instanceof ReadableStream ? 'half' : undefined,
+      headers,
     }
-    response = await network.fetch(targetUrl, requestInit)
+    for (let redirectCount = 0; ; redirectCount++) {
+      let hop: Response
+      try {
+        hop = await network.fetch(state.url.toString(), {
+          method: state.method,
+          headers: state.headers,
+          body: state.body,
+          credentials: 'omit', // Don't send cookies to third parties
+          signal: controller.signal,
+          redirect: 'manual',
+        })
+      }
+      catch (err) {
+        log('[proxy] Upstream error:', err)
+        throw upstreamFetchError(err, timedOut)
+      }
+      log('[proxy] Response:', hop.status, hop.statusText)
+
+      if (!isUpstreamRedirect(hop.status)) {
+        response = hop
+        break
+      }
+
+      // Follow the redirect only after the hop passes the initial target's checks.
+      let next: ProxyRedirectState
+      try {
+        next = resolveProxyRedirect(hop, state, redirectCount, hopAllowed)
+      }
+      catch (err) {
+        await hop.body?.cancel(err as Error).catch(cancelError => Object.assign(err as Error, { cleanupError: cancelError }))
+        throw err
+      }
+      const redirectDiscarded = new Error('Upstream redirect response body discarded')
+      await hop.body?.cancel(redirectDiscarded).catch(cancelError => Object.assign(redirectDiscarded, { cause: cancelError }))
+      log('[proxy] Following redirect:', next.url.toString())
+      state = next
+    }
     clearTimeout(timeoutId)
   }
   catch (err) {
     clearTimeout(timeoutId)
     await closePublicNetworkDispatcher(network, err)
-    log('[proxy] Upstream error:', err)
-    const blockedPrivateNetwork = isPrivateNetworkResolutionError(err)
-    throw createError({
-      statusCode: blockedPrivateNetwork ? 403 : timedOut ? 504 : 502,
-      statusMessage: blockedPrivateNetwork ? 'Local network targets are not allowed' : timedOut ? 'Gateway Timeout' : 'Bad Gateway',
-      message: 'Proxy upstream request failed',
-      cause: err,
-      data: {
-        errorName: (err as Error)?.name,
-        errorCode: timedOut ? 'TIMEOUT' : (err as { code?: string })?.code,
-      },
-    })
+    throw err
   }
-  log('[proxy] Response:', response.status, response.statusText)
-
-  if (response.status >= 300 && response.status < 400 && response.status !== 304) {
-    clearTimeout(timeoutId)
-    const redirectError = createError({
-      statusCode: 502,
-      statusMessage: 'Unsafe upstream redirect',
-      message: 'Proxy upstream returned a redirect that was not followed',
-    })
-    await response.body?.cancel(redirectError).catch(cancelError => Object.assign(redirectError, { cleanupError: cancelError }))
-    await closePublicNetworkDispatcher(network, redirectError)
-    throw redirectError
-  }
+  log('[proxy] Upstream settled:', response.status)
 
   // Headers named by Connection are hop-by-hop too, including non-standard names.
   const responseConnectionHeaders = new Set(

--- a/packages/script/src/runtime/server/proxy-handler.ts
+++ b/packages/script/src/runtime/server/proxy-handler.ts
@@ -222,8 +222,8 @@ interface ProxyRedirectState {
 
 /**
  * Resolve an upstream redirect into the next request state, mirroring the
- * fetch spec: 300/301/302 replay a POST as a GET without a body, 303 replays
- * every non-idempotent method as a GET, 307/308 preserve method and body.
+ * fetch spec: 301/302 replay a POST as a GET without a body, 303 replays
+ * every non-idempotent method as a GET, 300/307/308 preserve method and body.
  * The hop is only returned after it passes the initial target's checks.
  */
 function resolveProxyRedirect(
@@ -269,7 +269,7 @@ function resolveProxyRedirect(
   }
 
   const switchToGet = (response.status === 303 && state.method !== 'GET' && state.method !== 'HEAD')
-    || ((response.status === 300 || response.status === 301 || response.status === 302) && state.method === 'POST')
+    || ((response.status === 301 || response.status === 302) && state.method === 'POST')
   if (!switchToGet)
     return { ...state, url: nextUrl }
 

--- a/packages/script/src/runtime/server/proxy-handler.ts
+++ b/packages/script/src/runtime/server/proxy-handler.ts
@@ -31,6 +31,10 @@ const CLIENT_HINT_VERSION_RE = /;v="(\d+)\.[^"]*"/g
 const MAX_TRANSFORM_BODY_SIZE = 2 * 1024 * 1024
 const UPSTREAM_TIMEOUT_MS = 15000
 const MAX_UPSTREAM_REDIRECTS = 5
+/** Redirect statuses a fetch follows. Other 3xx responses reach the client unchanged. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+/** Fetch request-body-header names, removed when a redirect drops the body. */
+const REQUEST_BODY_HEADERS = ['content-encoding', 'content-language', 'content-length', 'content-location', 'content-type']
 const SKIP_RESPONSE_HEADERS = new Set([
   'alt-svc',
   'clear-site-data',
@@ -195,7 +199,7 @@ function stripQueryFingerprinting(
  */
 
 function isUpstreamRedirect(status: number): boolean {
-  return status >= 300 && status < 400 && status !== 304
+  return REDIRECT_STATUSES.has(status)
 }
 
 /** Map a transport failure to the gateway error the client should see. */
@@ -223,7 +227,7 @@ interface ProxyRedirectState {
 /**
  * Resolve an upstream redirect into the next request state, mirroring the
  * fetch spec: 301/302 replay a POST as a GET without a body, 303 replays
- * every non-idempotent method as a GET, 300/307/308 preserve method and body.
+ * every non-idempotent method as a GET, 307/308 preserve method and body.
  * The hop is only returned after it passes the initial target's checks.
  */
 function resolveProxyRedirect(
@@ -274,7 +278,7 @@ function resolveProxyRedirect(
     return { ...state, url: nextUrl }
 
   const headers = { ...state.headers }
-  for (const header of ['content-type', 'content-encoding', 'content-length'])
+  for (const header of REQUEST_BODY_HEADERS)
     delete headers[header]
   return { url: nextUrl, method: 'GET', body: undefined, headers }
 }

--- a/test/unit/proxy-handler-body.test.ts
+++ b/test/unit/proxy-handler-body.test.ts
@@ -45,7 +45,7 @@ describe('proxy handler request bodies (#836)', () => {
   let capturedFetchBody: BodyInit | null | undefined
   let capturedFetchDuplex: 'half' | undefined
   let capturedUrl = ''
-  let capturedRequests: { method: string, url: string }[] = []
+  let capturedRequests: { method: string, url: string, headers: Record<string, string> }[] = []
   let releaseStream: (() => void) | undefined
   const realFetch = globalThis.fetch
 
@@ -53,6 +53,7 @@ describe('proxy handler request bodies (#836)', () => {
     const upstreamApp = createApp()
     upstreamApp.use('/', defineEventHandler(async (event) => {
       capturedUrl = getRequestURL(event).pathname + getRequestURL(event).search
+      capturedRequests.push({ method: event.method, url: capturedUrl, headers: Object.fromEntries(event.headers) })
       if (getRequestURL(event).pathname === '/redirect')
         return sendRedirect(event, '/redirected', 302)
       if (getRequestURL(event).pathname === '/redirect-post')
@@ -97,7 +98,6 @@ describe('proxy handler request bodies (#836)', () => {
       capturedContentLength = event.headers.get('content-length') ?? undefined
       capturedContentType = event.headers.get('content-type') ?? undefined
       capturedMethod = event.method
-      capturedRequests.push({ method: event.method, url: getRequestURL(event).pathname + getRequestURL(event).search })
       return { status: 1 }
     }))
 
@@ -261,7 +261,11 @@ describe('proxy handler request bodies (#836)', () => {
   it('follows a redirect and re-validates the hop against the allowlist (#885)', async () => {
     const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-post`, {
       method: 'POST',
-      headers: { 'content-type': 'text/plain' },
+      headers: {
+        'content-type': 'text/plain',
+        'content-language': 'en',
+        'content-location': 'https://example.com/track',
+      },
       body: 'track=1',
     })
 
@@ -270,6 +274,10 @@ describe('proxy handler request bodies (#836)', () => {
     // A 302 replays as GET without a body, the same as a browser fetch would.
     expect(capturedMethod).toBe('GET')
     expect(capturedBody).toHaveLength(0)
+    // The fetch spec drops every request-body header with the body.
+    const replayHeaders = capturedRequests.at(-1)!.headers
+    for (const header of ['content-type', 'content-encoding', 'content-language', 'content-length', 'content-location'])
+      expect(replayHeaders).not.toHaveProperty(header)
   })
 
   it('replays the buffered body when a 307 preserves the method', async () => {
@@ -286,17 +294,16 @@ describe('proxy handler request bodies (#836)', () => {
     expect(capturedContentLength).toBe('7')
   })
 
-  it('replays the original method and body when upstream answers 300 with a Location', async () => {
+  it('passes a 300 through unchanged instead of replaying the request', async () => {
     const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-300`, {
       method: 'POST',
       headers: { 'content-type': 'text/plain' },
       body: 'track=1',
     })
 
-    expect(response.status).toBe(200)
-    expect(capturedUrl).toBe('/final')
-    expect(capturedMethod).toBe('POST')
-    expect(capturedBody.toString()).toBe('track=1')
+    // 300 is not a fetch redirect status, so a browser fetch would surface it as-is.
+    expect(response.status).toBe(300)
+    expect(capturedRequests.map(request => request.url)).toEqual(['/redirect-300'])
   })
 
   it('follows an absolute redirect to another allowlisted host', async () => {
@@ -311,7 +318,7 @@ describe('proxy handler request bodies (#836)', () => {
 
     expect(response.status).toBe(502)
     expect(response.statusText).toBe('Unsafe upstream redirect')
-    expect(capturedRequests.every(request => !request.url.includes('steal'))).toBe(true)
+    expect(capturedRequests.map(request => request.url)).toEqual(['/redirect-unallowed-host'])
   })
 
   it('rejects a redirect to a local network host', async () => {
@@ -332,6 +339,8 @@ describe('proxy handler request bodies (#836)', () => {
 
     expect(response.status).toBe(502)
     expect(response.statusText).toBe('Too many upstream redirects')
+    // The initial request plus five followed hops; the sixth redirect is refused.
+    expect(capturedRequests).toHaveLength(6)
   })
 
   it('strips response headers named by the upstream Connection header', async () => {

--- a/test/unit/proxy-handler-body.test.ts
+++ b/test/unit/proxy-handler-body.test.ts
@@ -59,6 +59,11 @@ describe('proxy handler request bodies (#836)', () => {
         return sendRedirect(event, '/final', 302)
       if (getRequestURL(event).pathname === '/redirect-307')
         return sendRedirect(event, '/final', 307)
+      if (getRequestURL(event).pathname === '/redirect-300') {
+        setResponseStatus(event, 300)
+        setHeader(event, 'Location', '/final')
+        return null
+      }
       if (getRequestURL(event).pathname === '/redirect-cross-host')
         return sendRedirect(event, 'https://redirect.test/final', 302)
       if (getRequestURL(event).pathname === '/redirect-unallowed-host')
@@ -279,6 +284,19 @@ describe('proxy handler request bodies (#836)', () => {
     expect(capturedMethod).toBe('POST')
     expect(capturedBody.toString()).toBe('track=1')
     expect(capturedContentLength).toBe('7')
+  })
+
+  it('replays the original method and body when upstream answers 300 with a Location', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-300`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: 'track=1',
+    })
+
+    expect(response.status).toBe(200)
+    expect(capturedUrl).toBe('/final')
+    expect(capturedMethod).toBe('POST')
+    expect(capturedBody.toString()).toBe('track=1')
   })
 
   it('follows an absolute redirect to another allowlisted host', async () => {

--- a/test/unit/proxy-handler-body.test.ts
+++ b/test/unit/proxy-handler-body.test.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'node:http'
 import { createServer } from 'node:http'
 import { gzipSync } from 'node:zlib'
-import { createApp, defineEventHandler, getRequestURL, readRawBody, sendRedirect, setHeader, toNodeListener } from 'h3'
+import { createApp, defineEventHandler, getRequestURL, readRawBody, sendRedirect, setHeader, setResponseStatus, toNodeListener } from 'h3'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import proxyHandler, { withResponseBodyIdleTimeout } from '../../packages/script/src/runtime/server/proxy-handler'
 
@@ -12,6 +12,7 @@ vi.mock('#nuxt-scripts/nitro', () => ({
       domainPrivacy: {
         '127.0.0.1': true,
         'upstream.test': true,
+        'redirect.test': true,
       },
       debug: false,
     },
@@ -40,9 +41,11 @@ describe('proxy handler request bodies (#836)', () => {
   let capturedBody = Buffer.alloc(0)
   let capturedContentLength: string | undefined
   let capturedContentType: string | undefined
+  let capturedMethod: string | undefined
   let capturedFetchBody: BodyInit | null | undefined
   let capturedFetchDuplex: 'half' | undefined
   let capturedUrl = ''
+  let capturedRequests: { method: string, url: string }[] = []
   let releaseStream: (() => void) | undefined
   const realFetch = globalThis.fetch
 
@@ -52,6 +55,22 @@ describe('proxy handler request bodies (#836)', () => {
       capturedUrl = getRequestURL(event).pathname + getRequestURL(event).search
       if (getRequestURL(event).pathname === '/redirect')
         return sendRedirect(event, '/redirected', 302)
+      if (getRequestURL(event).pathname === '/redirect-post')
+        return sendRedirect(event, '/final', 302)
+      if (getRequestURL(event).pathname === '/redirect-307')
+        return sendRedirect(event, '/final', 307)
+      if (getRequestURL(event).pathname === '/redirect-cross-host')
+        return sendRedirect(event, 'https://redirect.test/final', 302)
+      if (getRequestURL(event).pathname === '/redirect-unallowed-host')
+        return sendRedirect(event, 'https://evil.test/steal', 302)
+      if (getRequestURL(event).pathname === '/redirect-local-host')
+        return sendRedirect(event, 'http://localhost/steal', 302)
+      if (getRequestURL(event).pathname === '/redirect-no-location') {
+        setResponseStatus(event, 302)
+        return null
+      }
+      if (getRequestURL(event).pathname === '/redirect-loop')
+        return sendRedirect(event, '/redirect-loop', 302)
       if (getRequestURL(event).pathname === '/response-hop-headers') {
         setHeader(event, 'Connection', 'x-upstream-hop')
         setHeader(event, 'Clear-Site-Data', '"*"')
@@ -72,6 +91,8 @@ describe('proxy handler request bodies (#836)', () => {
       capturedBody = rawBody ? Buffer.from(rawBody) : Buffer.alloc(0)
       capturedContentLength = event.headers.get('content-length') ?? undefined
       capturedContentType = event.headers.get('content-type') ?? undefined
+      capturedMethod = event.method
+      capturedRequests.push({ method: event.method, url: getRequestURL(event).pathname + getRequestURL(event).search })
       return { status: 1 }
     }))
 
@@ -82,7 +103,7 @@ describe('proxy handler request bodies (#836)', () => {
     globalThis.fetch = (input, init) => {
       const requestUrl = input instanceof Request ? input.url : String(input)
       const url = new URL(requestUrl)
-      if (url.hostname === 'upstream.test') {
+      if (url.hostname === 'upstream.test' || url.hostname === 'redirect.test') {
         capturedFetchBody = init?.body
         capturedFetchDuplex = (init as RequestInit & { duplex?: 'half' } | undefined)?.duplex
         const redirected = `http://127.0.0.1:${upstreamPort}${url.pathname}${url.search}`
@@ -102,9 +123,11 @@ describe('proxy handler request bodies (#836)', () => {
     capturedBody = Buffer.alloc(0)
     capturedContentLength = undefined
     capturedContentType = undefined
+    capturedMethod = undefined
     capturedFetchBody = undefined
     capturedFetchDuplex = undefined
     capturedUrl = ''
+    capturedRequests = []
     releaseStream = undefined
   })
 
@@ -126,8 +149,9 @@ describe('proxy handler request bodies (#836)', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(capturedFetchBody).toBeInstanceOf(ReadableStream)
-    expect(capturedFetchDuplex).toBe('half')
+    expect(capturedFetchBody).toBeInstanceOf(Uint8Array)
+    expect(capturedFetchDuplex).toBeUndefined()
+    expect(Buffer.from(capturedFetchBody as Uint8Array).equals(compressed)).toBe(true)
     expect(capturedBody.equals(compressed)).toBe(true)
     expect(capturedContentType).toBe('text/plain')
   })
@@ -229,11 +253,67 @@ describe('proxy handler request bodies (#836)', () => {
     expect(capturedUrl).toBe('/collect?tag=a&tag=b&hardwareConcurrency=16')
   })
 
-  it('rejects upstream redirects instead of following an unchecked target', async () => {
-    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect`)
+  it('follows a redirect and re-validates the hop against the allowlist (#885)', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-post`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: 'track=1',
+    })
+
+    expect(response.status).toBe(200)
+    expect(capturedUrl).toBe('/final')
+    // A 302 replays as GET without a body, the same as a browser fetch would.
+    expect(capturedMethod).toBe('GET')
+    expect(capturedBody).toHaveLength(0)
+  })
+
+  it('replays the buffered body when a 307 preserves the method', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-307`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: 'track=1',
+    })
+
+    expect(response.status).toBe(200)
+    expect(capturedUrl).toBe('/final')
+    expect(capturedMethod).toBe('POST')
+    expect(capturedBody.toString()).toBe('track=1')
+    expect(capturedContentLength).toBe('7')
+  })
+
+  it('follows an absolute redirect to another allowlisted host', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-cross-host`)
+
+    expect(response.status).toBe(200)
+    expect(capturedUrl).toBe('/final')
+  })
+
+  it('rejects a redirect to a host outside the allowlist', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-unallowed-host`)
 
     expect(response.status).toBe(502)
-    expect(capturedUrl).toBe('/redirect')
+    expect(response.statusText).toBe('Unsafe upstream redirect')
+    expect(capturedRequests.every(request => !request.url.includes('steal'))).toBe(true)
+  })
+
+  it('rejects a redirect to a local network host', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-local-host`)
+
+    expect(response.status).toBe(502)
+    expect(response.statusText).toBe('Unsafe upstream redirect')
+  })
+
+  it('rejects a redirect without a Location header', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-no-location`)
+
+    expect(response.status).toBe(502)
+  })
+
+  it('rejects a redirect chain that exceeds the limit', async () => {
+    const response = await realFetch(`http://127.0.0.1:${proxyPort}/_scripts/p/upstream.test/redirect-loop`)
+
+    expect(response.status).toBe(502)
+    expect(response.statusText).toBe('Too many upstream redirects')
   })
 
   it('strips response headers named by the upstream Connection header', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Closes #885

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Meta Pixel events were silently dropped: the proxy answered Facebook's intermittent 302 from `/tr` with a 502 Unsafe upstream redirect, so the beacon never reached its destination. This starts from issue #885.

Redirects are now followed the way a browser fetch would follow them, but only after each hop passes the same HTTPS, public network, and domain allowlist checks as the original target, with a limit of five hops. A 302 replays as GET without the body and a 307 keeps it, matching the fetch spec.

One tradeoff to flag: proxied request bodies are now buffered under the same 2 MiB cap the privacy transforms already enforced, so an oversized beacon gets a 413 instead of streaming through.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).